### PR TITLE
Feat/fin 0 mapping idempotency parity 2026 04 21

### DIFF
--- a/docs/contracts/finance-fin0-openapi-mapping.md
+++ b/docs/contracts/finance-fin0-openapi-mapping.md
@@ -22,3 +22,4 @@
 ## Idempotency-Key (8.7)
 
 - OpenAPI dokumentiert Header `Idempotency-Key` für Zahlungseingang; technische Eindeutigkeit `(tenant_id, idempotency_key)` im FIN-2/FIN-3-Implementierungs-PR.
+- **FIN-0-Stub (`src/api/finance-fin0-stubs.ts`):** Header wird **case-insensitive** gelesen; Wert muss **UUID** sein — sonst `400` / `VALIDATION_FAILED` (Zod), konsistent zu `docs/api-contract.yaml` (`components.parameters.IdempotencyKey`) und `docs/contracts/qa-fin-0-stub-test-matrix.md`.

--- a/src/api/finance-fin0-stubs.ts
+++ b/src/api/finance-fin0-stubs.ts
@@ -51,7 +51,8 @@ function headerValueInsensitive(
 /** OpenAPI-Parameter `Idempotency-Key` (case-insensitive wie HTTP). */
 function parseIdempotencyKey(headers: Record<string, string | string[] | undefined>): string {
   const raw = headerValueInsensitive(headers, "Idempotency-Key");
-  return z.string().uuid().parse(raw);
+  const trimmed = typeof raw === "string" ? raw.trim() : raw;
+  return z.string().uuid().parse(trimmed);
 }
 
 /**

--- a/test/finance-fin0-stubs.test.ts
+++ b/test/finance-fin0-stubs.test.ts
@@ -130,6 +130,45 @@ describe("FIN-0 finance HTTP stubs (fail-closed)", () => {
     expect((res.json() as { code: string }).code).toBe("TRACEABILITY_LINK_MISSING");
   });
 
+  it("POST /finance/payments/intake accepts Idempotency-Key header name case-insensitive (UPPERCASE)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/finance/payments/intake",
+      headers: {
+        ...buildHeaders(),
+        "IDEMPOTENCY-KEY": randomUUID(),
+      },
+      payload: {
+        invoiceId: randomUUID(),
+        amountCents: 100,
+        externalReference: "ext-1",
+        reason: "FIN-0 stub test payment idem upper",
+      },
+    });
+    expect(res.statusCode).toBe(422);
+    expect((res.json() as { code: string }).code).toBe("TRACEABILITY_LINK_MISSING");
+  });
+
+  it("POST /finance/payments/intake trims Idempotency-Key value before UUID parse", async () => {
+    const idem = randomUUID();
+    const res = await app.inject({
+      method: "POST",
+      url: "/finance/payments/intake",
+      headers: {
+        ...buildHeaders(),
+        "Idempotency-Key": `  ${idem}  `,
+      },
+      payload: {
+        invoiceId: randomUUID(),
+        amountCents: 100,
+        externalReference: "ext-1",
+        reason: "FIN-0 stub test payment idem trim",
+      },
+    });
+    expect(res.statusCode).toBe(422);
+    expect((res.json() as { code: string }).code).toBe("TRACEABILITY_LINK_MISSING");
+  });
+
   it("rejects tenant header mismatch with 403", async () => {
     const res = await app.inject({
       method: "POST",


### PR DESCRIPTION
## Scope
FIN-0 Zahlungseingang-Stub: `Idempotency-Key` Wert wird getrimmt; Regressionstests für Header-Name in UPPERCASE und Whitespace um UUID. Kein FIN-2, keine neuen Domain-`code`-Werte.

## Änderungen
- `src/api/finance-fin0-stubs.ts` — trim vor UUID-Parse
- `test/finance-fin0-stubs.test.ts` — +2 Tests
- (falls im Diff) Doku-Abgleich OpenAPI / Stub / Testmatrix aus vorherigem Commit auf diesem Branch

## Checkliste
- [x] `npm test` / `npm run typecheck` grün (lokal erledigt)
- [x] Nach Merge: QA Merge-Evidence nach `docs/contracts/qa-fin-0-gate-readiness.md` Abschnitt 5 (PR-Head vor Merge: Vorlage 5a-pre)

**Scope-Zeile:** FIN-0 Stub/Tests; kein FIN-2.