### PR TITLE
feat(web): PWA Login und Passwort-Reset (#/login, #/password-reset)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState, type ReactElement } from "re
 import { AppShell } from "./components/AppShell.js";
 import { DocumentTextPanels } from "./components/DocumentTextPanels.js";
 import { FinancePreparation } from "./components/FinancePreparation.js";
+import { LoginPage } from "./components/LoginPage.js";
+import { PasswordResetPage } from "./components/PasswordResetPage.js";
 import { FINANCE_PREP_HASH, useHashRoute } from "./lib/hash-route.js";
 import {
   CANONICAL_EXPORT_INVOICE_ACTION_ID,
@@ -11,7 +13,7 @@ import {
   executeActionWithSotGuard,
 } from "./lib/action-executor.js";
 import { ApiError } from "./lib/api-error.js";
-import { createApiClient } from "./lib/api-client.js";
+import { createApiClient, resolveApiBaseUrl } from "./lib/api-client.js";
 import {
   clearDocumentScopedKeys,
   clearPersistedSession,
@@ -64,7 +66,11 @@ function saveDocPrefs(tenantId: string, documentId: string, entityType: EntityTy
 }
 
 export default function App() {
-  const defaultApi = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
+  const viteDefaultTenant =
+    typeof import.meta.env.VITE_DEFAULT_TENANT_ID === "string" && import.meta.env.VITE_DEFAULT_TENANT_ID.trim()
+      ? (import.meta.env.VITE_DEFAULT_TENANT_ID as string).trim()
+      : undefined;
+  const defaultApi = resolveApiBaseUrl(import.meta.env.VITE_API_BASE_URL as string | undefined);
   const [apiBase, setApiBase] = useState(defaultApi);
   const persisted = loadPersistedSession();
   const [token, setToken] = useState(persisted.token);
@@ -120,7 +126,7 @@ export default function App() {
   const client = useMemo(
     () =>
       createApiClient({
-        baseUrl: apiBase,
+        baseUrl: resolveApiBaseUrl(apiBase),
         getToken: () => token,
         getTenantId: () => tenantId,
       }),
@@ -132,6 +138,8 @@ export default function App() {
 
   const hashPath = useHashRoute();
   const showFinancePrep = hashPath === "/finanz-vorbereitung";
+  const showLogin = hashPath === "/login";
+  const showPasswordReset = hashPath === "/password-reset";
 
   useEffect(() => {
     if (tenantId !== prevTenant) {
@@ -376,6 +384,10 @@ export default function App() {
         <a href="#/">Shell / Dokument</a>
         {" · "}
         <a href={FINANCE_PREP_HASH}>Finanz (Vorbereitung)</a>
+        {" · "}
+        <a href="#/login">Anmeldung</a>
+        {" · "}
+        <a href="#/password-reset">Passwort vergessen</a>
       </nav>
       {banner?.kind === "error" ? (
         <div className="error-banner" role="alert">
@@ -406,7 +418,27 @@ export default function App() {
         <FinancePreparation />
       ) : null}
 
-      {!showFinancePrep ? (
+      {showLogin ? (
+        <LoginPage
+          apiBase={apiBase}
+          defaultTenantId={viteDefaultTenant}
+          onSuccess={(r) => {
+            setToken(r.accessToken);
+            setTenantId(r.tenantId);
+            setSessionMode("session");
+            persistSession(r.accessToken, r.tenantId, "session");
+            setBanner({ kind: "ok", text: `Angemeldet — Rolle ${r.role}. Token in sessionStorage (Tab).` });
+            window.location.hash = "#/";
+          }}
+          onNavigateHome={() => {
+            window.location.hash = "#/";
+          }}
+        />
+      ) : null}
+
+      {showPasswordReset ? <PasswordResetPage apiBase={apiBase} defaultTenantId={viteDefaultTenant} /> : null}
+
+      {!showFinancePrep && !showLogin && !showPasswordReset ? (
         <>
       <section className="panel">
         <h2>Sitzung &amp; API</h2>

--- a/apps/web/src/components/LoginPage.tsx
+++ b/apps/web/src/components/LoginPage.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { ApiError } from "../lib/api-error.js";
+import { loginWithPassword, type LoginResponse } from "../lib/api-client.js";
+
+type Props = {
+  apiBase: string;
+  defaultTenantId?: string;
+  onSuccess: (r: LoginResponse) => void;
+  onNavigateHome: () => void;
+};
+
+export function LoginPage({ apiBase, defaultTenantId, onSuccess, onNavigateHome }: Props) {
+  const [tenantId, setTenantId] = useState(defaultTenantId ?? "");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<{ text: string; code?: string; correlationId?: string } | null>(null);
+
+  const submit = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const r = await loginWithPassword(apiBase, { tenantId, email, password });
+      onSuccess(r);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError({
+          text: e.envelope.message,
+          code: e.envelope.code,
+          correlationId: e.envelope.correlationId,
+        });
+      } else {
+        setError({ text: e instanceof Error ? e.message : String(e) });
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="panel" style={{ maxWidth: "28rem" }}>
+      <h2>Anmeldung</h2>
+      <p style={{ fontSize: "0.85rem", color: "var(--text-secondary)", marginTop: 0 }}>
+        Passwort-Login gemäß Backend (<code>POST /auth/login</code>). Nach erfolgreicher Anmeldung wird die Session im{" "}
+        <strong>sessionStorage</strong> abgelegt (Tab-Lebensdauer).
+      </p>
+      {error ? (
+        <div className="error-banner" role="alert">
+          <strong>{error.code ? `${error.code}: ` : ""}</strong>
+          {error.text}
+          {error.correlationId ? (
+            <>
+              {" "}
+              <code>correlationId={error.correlationId}</code>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+      <div className="field-grid">
+        {defaultTenantId ? null : (
+          <label className="field">
+            <span>Mandanten-ID (UUID)</span>
+            <input type="text" value={tenantId} onChange={(e) => setTenantId(e.target.value)} autoComplete="off" />
+          </label>
+        )}
+        <label className="field">
+          <span>E-Mail</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="username"
+          />
+        </label>
+        <label className="field">
+          <span>Passwort</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
+          />
+        </label>
+      </div>
+      <div className="actions-row" style={{ marginTop: "1rem" }}>
+        <button type="button" className="btn" disabled={busy} onClick={() => void submit()}>
+          Anmelden
+        </button>
+        <button type="button" className="btn secondary" disabled={busy} onClick={onNavigateHome}>
+          Abbrechen
+        </button>
+      </div>
+      <p style={{ fontSize: "0.8rem", marginTop: "1rem" }}>
+        <a href="#/password-reset">Passwort vergessen?</a>
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/components/PasswordResetPage.tsx
+++ b/apps/web/src/components/PasswordResetPage.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from "react";
+import { ApiError } from "../lib/api-error.js";
+import { confirmPasswordReset, requestPasswordReset } from "../lib/api-client.js";
+import { readHashQuery } from "../lib/hash-route.js";
+
+type Props = {
+  apiBase: string;
+  defaultTenantId?: string;
+};
+
+export function PasswordResetPage({ apiBase, defaultTenantId }: Props) {
+  const [step, setStep] = useState<"request" | "confirm">("request");
+  const [tenantId, setTenantId] = useState(defaultTenantId ?? "");
+  const [email, setEmail] = useState("");
+  const [token, setToken] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<{ text: string; code?: string; correlationId?: string } | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+
+  useEffect(() => {
+    const q = readHashQuery();
+    const t = q.get("token")?.trim();
+    if (t) {
+      setToken(t);
+      setStep("confirm");
+    }
+  }, []);
+
+  const sendRequest = async () => {
+    setBusy(true);
+    setError(null);
+    setInfo(null);
+    try {
+      const r = await requestPasswordReset(apiBase, { tenantId, email });
+      setInfo(r.message);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError({
+          text: e.envelope.message,
+          code: e.envelope.code,
+          correlationId: e.envelope.correlationId,
+        });
+      } else {
+        setError({ text: e instanceof Error ? e.message : String(e) });
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const sendConfirm = async () => {
+    setBusy(true);
+    setError(null);
+    setInfo(null);
+    try {
+      await confirmPasswordReset(apiBase, { token, password });
+      setInfo("Passwort wurde geändert. Sie können sich anmelden.");
+      setTimeout(() => {
+        window.location.hash = "#/login";
+      }, 1500);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setError({
+          text: e.envelope.message,
+          code: e.envelope.code,
+          correlationId: e.envelope.correlationId,
+        });
+      } else {
+        setError({ text: e instanceof Error ? e.message : String(e) });
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="panel" style={{ maxWidth: "28rem" }}>
+      <h2>Passwort zurücksetzen</h2>
+      {error ? (
+        <div className="error-banner" role="alert">
+          <strong>{error.code ? `${error.code}: ` : ""}</strong>
+          {error.text}
+          {error.correlationId ? (
+            <>
+              {" "}
+              <code>correlationId={error.correlationId}</code>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+      {info ? (
+        <div className="success-banner">
+          <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>{info}</pre>
+        </div>
+      ) : null}
+
+      {step === "request" ? (
+        <>
+          <p style={{ fontSize: "0.85rem", color: "var(--text-secondary)", marginTop: 0 }}>
+            Link wird per E-Mail versendet, wenn SMTP und Datenbank konfiguriert sind.
+          </p>
+          <div className="field-grid">
+            {defaultTenantId ? null : (
+              <label className="field">
+                <span>Mandanten-ID</span>
+                <input type="text" value={tenantId} onChange={(e) => setTenantId(e.target.value)} />
+              </label>
+            )}
+            <label className="field">
+              <span>E-Mail</span>
+              <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+            </label>
+          </div>
+          <div className="actions-row" style={{ marginTop: "1rem" }}>
+            <button type="button" className="btn" disabled={busy} onClick={() => void sendRequest()}>
+              Link anfordern
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          <p style={{ fontSize: "0.85rem", color: "var(--text-secondary)", marginTop: 0 }}>
+            Neues Passwort setzen (mindestens 12 Zeichen).
+          </p>
+          <div className="field-grid">
+            <label className="field">
+              <span>Token (aus E-Mail-Link)</span>
+              <input type="text" value={token} onChange={(e) => setToken(e.target.value)} />
+            </label>
+            <label className="field">
+              <span>Neues Passwort</span>
+              <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+            </label>
+          </div>
+          <div className="actions-row" style={{ marginTop: "1rem" }}>
+            <button type="button" className="btn" disabled={busy} onClick={() => void sendConfirm()}>
+              Passwort speichern
+            </button>
+          </div>
+        </>
+      )}
+
+      <p style={{ fontSize: "0.8rem", marginTop: "1rem" }}>
+        <a href="#/login">Zur Anmeldung</a>
+        {" · "}
+        <a href="#/">Zur Shell</a>
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,5 +1,97 @@
 import { ApiError } from "./api-error.js";
 
+/** Vite: leere `VITE_API_BASE_URL=""` bleibt leer → relative URLs auf :5173. Default wie Backend-Port 3000. */
+export const DEFAULT_API_BASE_URL = "http://localhost:3000";
+
+export function resolveApiBaseUrl(baseUrl: string | undefined): string {
+  const t = baseUrl?.trim();
+  return t && t.length > 0 ? t : DEFAULT_API_BASE_URL;
+}
+
+function correlationFromResponse(res: Response): string | undefined {
+  return res.headers.get("x-correlation-id") ?? res.headers.get("x-request-id") ?? undefined;
+}
+
+export type LoginResponse = {
+  accessToken: string;
+  tokenType: string;
+  expiresIn: number;
+  tenantId: string;
+  userId: string;
+  role: string;
+};
+
+export type LoginCredentials = { tenantId: string; email: string; password: string };
+
+export async function loginWithPassword(baseUrl: string, credentials: LoginCredentials): Promise<LoginResponse> {
+  const root = resolveApiBaseUrl(baseUrl).replace(/\/$/, "");
+  const res = await fetch(`${root}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      tenantId: credentials.tenantId.trim(),
+      email: credentials.email.trim(),
+      password: credentials.password,
+    }),
+  });
+  const text = await res.text();
+  let parsed: unknown;
+  try {
+    parsed = text ? JSON.parse(text) : undefined;
+  } catch {
+    parsed = undefined;
+  }
+  if (!res.ok) {
+    throw new ApiError(res.status, parsed ?? text, { requestIdFromHeader: correlationFromResponse(res) });
+  }
+  return parsed as LoginResponse;
+}
+
+export async function requestPasswordReset(
+  baseUrl: string,
+  body: { tenantId: string; email: string },
+): Promise<{ ok: true; message: string }> {
+  const root = resolveApiBaseUrl(baseUrl).replace(/\/$/, "");
+  const res = await fetch(`${root}/auth/request-password-reset`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tenantId: body.tenantId.trim(), email: body.email.trim() }),
+  });
+  const text = await res.text();
+  let parsed: unknown;
+  try {
+    parsed = text ? JSON.parse(text) : undefined;
+  } catch {
+    parsed = undefined;
+  }
+  if (!res.ok) {
+    throw new ApiError(res.status, parsed ?? text, { requestIdFromHeader: correlationFromResponse(res) });
+  }
+  return parsed as { ok: true; message: string };
+}
+
+export async function confirmPasswordReset(
+  baseUrl: string,
+  body: { token: string; password: string },
+): Promise<void> {
+  const root = resolveApiBaseUrl(baseUrl).replace(/\/$/, "");
+  const res = await fetch(`${root}/auth/confirm-password-reset`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token: body.token, password: body.password }),
+  });
+  const text = await res.text();
+  let parsed: unknown;
+  try {
+    parsed = text ? JSON.parse(text) : undefined;
+  } catch {
+    parsed = undefined;
+  }
+  if (!res.ok) {
+    throw new ApiError(res.status, parsed ?? text, { requestIdFromHeader: correlationFromResponse(res) });
+  }
+}
+
 export type AllowedActionsResponse = {
   documentId: string;
   entityType: string;
@@ -46,7 +138,7 @@ export function createApiClient(options: {
     }
     if (!res.ok) {
       throw new ApiError(res.status, parsed ?? text, {
-        requestIdFromHeader: res.headers.get("x-request-id") ?? undefined,
+        requestIdFromHeader: correlationFromResponse(res),
       });
     }
     return parsed as T;

--- a/apps/web/src/lib/hash-route.ts
+++ b/apps/web/src/lib/hash-route.ts
@@ -2,11 +2,21 @@ import { useEffect, useState } from "react";
 
 /** Hash-Route zur read-only Finanz-Vorbereitungsseite (ohne react-router). */
 export const FINANCE_PREP_HASH = "#/finanz-vorbereitung";
+export const LOGIN_HASH = "#/login";
+export const PASSWORD_RESET_HASH = "#/password-reset";
 
 function normalizeHash(): string {
   const raw = window.location.hash.replace(/^#/, "");
-  if (raw === "" || raw === "/") return "/";
-  return raw.startsWith("/") ? raw : `/${raw}`;
+  const pathOnly = raw.split("?")[0] ?? "";
+  if (pathOnly === "" || pathOnly === "/") return "/";
+  return pathOnly.startsWith("/") ? pathOnly : `/${pathOnly}`;
+}
+
+/** Query-String der aktuellen Hash-URL (z. B. `token` bei Passwort-Reset). */
+export function readHashQuery(): URLSearchParams {
+  const raw = window.location.hash.replace(/^#/, "");
+  const qs = raw.includes("?") ? raw.slice(raw.indexOf("?") + 1) : "";
+  return new URLSearchParams(qs);
 }
 
 export function useHashRoute(): string {


### PR DESCRIPTION
## Inhalt
- Hash-Routen `#/login`, `#/password-reset` (Query `token` für Reset-Link)
- `loginWithPassword`, `requestPasswordReset`, `confirmPasswordReset` + `resolveApiBaseUrl` in `api-client.ts`
- `x-correlation-id` / `x-request-id` für ApiError-Fallback
- Nach erfolgreichem Login: Token + Tenant in sessionStorage (`session`-Modus)

## Hinweis
Direkter Push auf `main` ist durch Branch-Protection blockiert — Merge nur per PR mit grünem `backend`-Job.

## Merge von PR #4
Auth-Backend war bereits auf `main`; dieser PR schließt die PWA-Anbindung an.

Made with [Cursor](https://cursor.com)