### PR TITLE
feat(auth): Rolle VERTRIEB → VERTRIEB_BAULEITUNG

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -28,7 +28,7 @@ Details zu Postgres, `DATABASE_URL` und Prisma: [Root-`README.md`](../README.md)
 3. Backend starten (Port **3000**) mit CORS für die PWA-Origin, z. B.  
    `CORS_ORIGINS=http://localhost:5173 npm run dev`  
    (oder alles über Root-`.env`).
-4. Dev-Token (Repo-Root, gleiches Secret wie Backend): `npm run dev:token` — optional `npm run dev:token -- <tenantUuid> <ROLE>` (`ADMIN` \| `VERTRIEB` \| `GESCHAEFTSFUEHRUNG` \| `BUCHHALTUNG` \| `VIEWER`).
+4. Dev-Token (Repo-Root, gleiches Secret wie Backend): `npm run dev:token` — optional `npm run dev:token -- <tenantUuid> <ROLE>` (`ADMIN` \| `VERTRIEB_BAULEITUNG` \| `GESCHAEFTSFUEHRUNG` \| `BUCHHALTUNG` \| `VIEWER`).
 5. **PWA:** Repo-Root `npm run dev:web` oder hier `npm run dev`.
 6. In der UI: Token und **X-Tenant-Id** (muss zum Token passen, sonst `TENANT_SCOPE_VIOLATION`), Session-Modus, „Session anwenden“, „Allowed Actions laden“.
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "verify:ci:with-migrate": "npx prisma migrate deploy && npm run verify:ci",
     "docker:db-up": "docker compose up -d",
     "ensure:local-test-db": "node scripts/ensure-local-postgres-test-db.mjs",
-    "verify:ci:local-db": "npm run ensure:local-test-db && sh -c 'export DATABASE_URL=${DATABASE_URL:-postgresql://erp:erp@127.0.0.1:15432/erp_test} PERSISTENCE_DB_TEST_URL=${PERSISTENCE_DB_TEST_URL:-postgresql://erp:erp@127.0.0.1:15432/erp_test} && npm run verify:ci:with-migrate'",
+    "verify:ci:local-db": "npm run ensure:local-test-db && sh -c 'export DATABASE_URL=${DATABASE_URL:-postgresql://erp:erp@127.0.0.1:5432/erp_test} PERSISTENCE_DB_TEST_URL=${PERSISTENCE_DB_TEST_URL:-postgresql://erp:erp@127.0.0.1:5432/erp_test} && npm run verify:ci:with-migrate'",
     "validate:api-contract-yaml": "node scripts/validate-api-contract-yaml.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"

--- a/prisma/migrations/20260421220000_user_role_vertrieb_bauleitung/migration.sql
+++ b/prisma/migrations/20260421220000_user_role_vertrieb_bauleitung/migration.sql
@@ -1,0 +1,3 @@
+-- API-Rolle umbenannt: VERTRIEB → VERTRIEB_BAULEITUNG (fachlich „Vertrieb / Bauleitung“).
+UPDATE users SET role = 'VERTRIEB_BAULEITUNG' WHERE role = 'VERTRIEB';
+

--- a/scripts/ensure-local-postgres-test-db.mjs
+++ b/scripts/ensure-local-postgres-test-db.mjs
@@ -1,0 +1,58 @@
+/**
+ * Startet Repo-`docker compose` (Service `postgres`), wartet auf pg_isready und
+ * stellt sicher, dass die Datenbank `erp_test` existiert (idempotent; hilft bei alten Volumes).
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function composeExec(args, input) {
+  const r = spawnSync("docker", ["compose", ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    input,
+  });
+  const out = `${r.stderr ?? ""}${r.stdout ?? ""}`;
+  return { ok: r.status === 0, out };
+}
+
+async function main() {
+  const up = composeExec(["up", "-d"]);
+  if (!up.ok) {
+    console.error("docker compose up -d fehlgeschlagen:\n", up.out);
+    process.exit(1);
+  }
+  for (let i = 0; i < 45; i++) {
+    const pr = composeExec(["exec", "-T", "postgres", "pg_isready", "-U", "erp", "-d", "postgres"]);
+    if (pr.ok) break;
+    if (i === 44) {
+      console.error("Postgres nicht bereit nach 45s:\n", pr.out);
+      process.exit(1);
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  const cre = composeExec([
+    "exec",
+    "-T",
+    "postgres",
+    "psql",
+    "-U",
+    "erp",
+    "-d",
+    "postgres",
+    "-c",
+    "CREATE DATABASE erp_test OWNER erp;",
+  ]);
+  if (!cre.ok && !/already exists/i.test(cre.out)) {
+    console.error("CREATE DATABASE erp_test fehlgeschlagen:\n", cre.out);
+    process.exit(1);
+  }
+  console.log("Lokaler Postgres (Compose) bereit; Datenbank erp_test nutzbar.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/print-dev-token.ts
+++ b/scripts/print-dev-token.ts
@@ -12,8 +12,8 @@ try {
 }
 
 const tenantId = process.argv[2] ?? "11111111-1111-4111-8111-111111111111";
-const roleArg = process.argv[3] ?? "VERTRIEB";
-const role = roleArg as "ADMIN" | "VERTRIEB" | "GESCHAEFTSFUEHRUNG" | "BUCHHALTUNG" | "VIEWER";
+const roleArg = process.argv[3] ?? "VERTRIEB_BAULEITUNG";
+const role = roleArg as "ADMIN" | "VERTRIEB_BAULEITUNG" | "GESCHAEFTSFUEHRUNG" | "BUCHHALTUNG" | "VIEWER";
 
 const token = createSignedToken({
   sub: "77777777-7777-4777-8777-777777777777",

--- a/src/auth/password-login-config.ts
+++ b/src/auth/password-login-config.ts
@@ -4,7 +4,7 @@ const ROLE_SET = new Set<UserRole>([
   "ADMIN",
   "BUCHHALTUNG",
   "GESCHAEFTSFUEHRUNG",
-  "VERTRIEB",
+  "VERTRIEB_BAULEITUNG",
   "VIEWER",
 ]);
 
@@ -38,7 +38,8 @@ export function getPasswordLoginProfile(): PasswordLoginProfile | null {
   const emailNorm = (process.env.ERP_LOGIN_EMAIL ?? "admin@localhost").trim().toLowerCase();
   const tenantId = (process.env.ERP_LOGIN_TENANT_ID ?? "11111111-1111-4111-8111-111111111111").trim();
   const userId = (process.env.ERP_LOGIN_USER_ID ?? "77777777-7777-4777-8777-777777777777").trim();
-  const roleRaw = (process.env.ERP_LOGIN_ROLE ?? "ADMIN").trim().toUpperCase() as UserRole;
+  const roleUpper = (process.env.ERP_LOGIN_ROLE ?? "ADMIN").trim().toUpperCase();
+  const roleRaw = (roleUpper === "VERTRIEB" ? "VERTRIEB_BAULEITUNG" : roleUpper) as UserRole;
 
   if (!isUuid(tenantId)) {
     console.warn("[erp] ERP_LOGIN_TENANT_ID is not a valid UUID; password login disabled.");

--- a/src/auth/password-login.ts
+++ b/src/auth/password-login.ts
@@ -11,7 +11,7 @@ const TOKEN_TTL_SECONDS = 12 * 60 * 60;
 /** bcrypt-Vergleichspfad auch ohne Treffer in der DB (Timing). */
 const BCRYPT_TIMING_DUMMY = "$2a$12$zwXbNa9BhzOcCB5Ff3uvzeN0e5Q3XRyODJBz48ij3QvPWCtl5iWv.";
 
-const ROLE_SET = new Set<UserRole>(["ADMIN", "BUCHHALTUNG", "GESCHAEFTSFUEHRUNG", "VERTRIEB", "VIEWER"]);
+const ROLE_SET = new Set<UserRole>(["ADMIN", "BUCHHALTUNG", "GESCHAEFTSFUEHRUNG", "VERTRIEB_BAULEITUNG", "VIEWER"]);
 
 let cachedPasswordHash: string | null = null;
 
@@ -27,8 +27,13 @@ function ensurePasswordHash(plain: string): string {
   return cachedPasswordHash;
 }
 
-function isRole(value: string): value is UserRole {
-  return ROLE_SET.has(value as UserRole);
+function loginDbRoleAllowed(raw: string): boolean {
+  const normalized = raw === "VERTRIEB" ? "VERTRIEB_BAULEITUNG" : raw;
+  return ROLE_SET.has(normalized as UserRole);
+}
+
+function toUserRoleFromDb(raw: string): UserRole {
+  return (raw === "VERTRIEB" ? "VERTRIEB_BAULEITUNG" : raw) as UserRole;
 }
 
 export type PasswordLoginResult = {
@@ -51,15 +56,16 @@ async function loginViaDatabase(
   const row = user?.active ? user : null;
   const hash = row ? row.passwordHash : BCRYPT_TIMING_DUMMY;
   const passwordMatches = bcrypt.compareSync(password, hash);
-  if (!row || !passwordMatches || !isRole(row.role)) {
+  if (!row || !passwordMatches || !loginDbRoleAllowed(row.role)) {
     return null;
   }
+  const role = toUserRoleFromDb(row.role);
   const now = Math.floor(Date.now() / 1000);
   const exp = now + TOKEN_TTL_SECONDS;
   const token = createSignedToken({
     sub: row.id,
     tenantId: row.tenantId,
-    role: row.role,
+    role,
     exp,
   });
   return {
@@ -67,7 +73,7 @@ async function loginViaDatabase(
     expiresIn: exp - now,
     tenantId: row.tenantId,
     userId: row.id,
-    role: row.role,
+    role,
   };
 }
 

--- a/src/auth/token-auth.ts
+++ b/src/auth/token-auth.ts
@@ -80,6 +80,17 @@ export function createSignedToken(payload: TokenPayload): string {
   return `v1.${payloadBase64Url}.${signatureBase64Url}`;
 }
 
+const USER_ROLE_VALUES = new Set<string>(["ADMIN", "BUCHHALTUNG", "GESCHAEFTSFUEHRUNG", "VERTRIEB_BAULEITUNG", "VIEWER"]);
+
+/** Alte Tokens: Claim `VERTRIEB` wird wie `VERTRIEB_BAULEITUNG` behandelt (Anzeige „Vertrieb / Bauleitung“). */
+function normalizeRoleClaim(raw: string): UserRole {
+  const v = raw === "VERTRIEB" ? "VERTRIEB_BAULEITUNG" : raw;
+  if (!USER_ROLE_VALUES.has(v)) {
+    throw new DomainError("UNAUTHORIZED", "Token-Rolle ungültig", 401);
+  }
+  return v as UserRole;
+}
+
 export function verifyBearerToken(authorizationHeader: string): AuthContext {
   const [scheme, token] = authorizationHeader.split(" ");
   if (scheme !== "Bearer" || !token) {
@@ -97,17 +108,18 @@ export function verifyBearerToken(authorizationHeader: string): AuthContext {
   if (!timingSafeEqual(expectedSignature, receivedSignature)) {
     throw new DomainError("UNAUTHORIZED", "Token-Signatur ungültig", 401);
   }
-  let payload: TokenPayload;
+  let payload: { sub?: string; tenantId?: string; role?: string; exp?: number };
   try {
-    payload = JSON.parse(Buffer.from(payloadBase64Url, "base64url").toString("utf8")) as TokenPayload;
+    payload = JSON.parse(Buffer.from(payloadBase64Url, "base64url").toString("utf8")) as typeof payload;
   } catch {
     throw new DomainError("UNAUTHORIZED", "Token-Payload ungültig", 401);
   }
-  if (!payload.sub || !payload.tenantId || !payload.role || !payload.exp) {
+  if (!payload.sub || !payload.tenantId || typeof payload.role !== "string" || !payload.exp) {
     throw new DomainError("UNAUTHORIZED", "Token-Claims unvollständig", 401);
   }
   if (payload.exp <= Math.floor(Date.now() / 1000)) {
     throw new DomainError("UNAUTHORIZED", "Token abgelaufen", 401);
   }
-  return { userId: payload.sub, tenantId: payload.tenantId, role: payload.role };
+  const role = normalizeRoleClaim(payload.role);
+  return { userId: payload.sub, tenantId: payload.tenantId, role };
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,7 +1,7 @@
 export type UUID = string;
 export type TenantId = string;
 export type UserId = string;
-export type UserRole = "ADMIN" | "BUCHHALTUNG" | "GESCHAEFTSFUEHRUNG" | "VERTRIEB" | "VIEWER";
+export type UserRole = "ADMIN" | "BUCHHALTUNG" | "GESCHAEFTSFUEHRUNG" | "VERTRIEB_BAULEITUNG" | "VIEWER";
 
 export type OfferStatus =
   | "ENTWURF"

--- a/src/services/audit-service.ts
+++ b/src/services/audit-service.ts
@@ -51,7 +51,7 @@ export class AuditService {
 
   public async listByTenant(input: {
     tenantId: TenantId;
-    role: "ADMIN" | "BUCHHALTUNG" | "GESCHAEFTSFUEHRUNG" | "VERTRIEB" | "VIEWER";
+    role: "ADMIN" | "BUCHHALTUNG" | "GESCHAEFTSFUEHRUNG" | "VERTRIEB_BAULEITUNG" | "VIEWER";
     page: number;
     pageSize: number;
   }): Promise<{ data: AuditEventView[]; page: number; pageSize: number; total: number }> {

--- a/src/services/authorization-service.ts
+++ b/src/services/authorization-service.ts
@@ -38,7 +38,7 @@ const OFFER_STATUS_ACTION_BY_ROLE: Record<UserRole, string[]> = {
     "OFFER_SET_ABGELEHNT",
     "OFFER_CREATE_SUPPLEMENT",
   ],
-  VERTRIEB: [
+  VERTRIEB_BAULEITUNG: [
     "OFFER_SET_IN_FREIGABE",
     "OFFER_SET_VERSENDET",
     "OFFER_SET_ANGENOMMEN",
@@ -61,7 +61,7 @@ const SUPPLEMENT_ACTION_BY_ROLE: Record<UserRole, string[]> = {
     "SUPPLEMENT_APPLY_BILLING_IMPACT",
     "OFFER_CREATE_SUPPLEMENT",
   ],
-  VERTRIEB: [
+  VERTRIEB_BAULEITUNG: [
     "SUPPLEMENT_SET_IN_FREIGABE",
     "SUPPLEMENT_SET_VERSENDET",
     "SUPPLEMENT_SET_BEAUFTRAGT",
@@ -82,7 +82,7 @@ const SUPPLEMENT_ACTION_BY_ROLE: Record<UserRole, string[]> = {
 const EXPORT_ACTIONS_BY_ROLE: Record<UserRole, string[]> = {
   ADMIN: ["EXPORT_INVOICE", "EXPORT_OFFER_VERSION", "EXPORT_SUPPLEMENT_VERSION"],
   BUCHHALTUNG: ["EXPORT_INVOICE"],
-  VERTRIEB: ["EXPORT_OFFER_VERSION", "EXPORT_SUPPLEMENT_VERSION"],
+  VERTRIEB_BAULEITUNG: ["EXPORT_OFFER_VERSION", "EXPORT_SUPPLEMENT_VERSION"],
   GESCHAEFTSFUEHRUNG: ["EXPORT_INVOICE", "EXPORT_OFFER_VERSION", "EXPORT_SUPPLEMENT_VERSION"],
   VIEWER: [],
 };
@@ -97,7 +97,7 @@ const MEASUREMENT_ACTION_BY_ROLE: Record<UserRole, string[]> = {
     "MEASUREMENT_SET_ARCHIVIERT",
     "MEASUREMENT_CREATE_VERSION",
   ],
-  VERTRIEB: [
+  VERTRIEB_BAULEITUNG: [
     "MEASUREMENT_CREATE",
     "MEASUREMENT_UPDATE_POSITIONS",
     "MEASUREMENT_SET_GEPRUEFT",
@@ -119,7 +119,7 @@ const LV_ACTION_BY_ROLE: Record<UserRole, string[]> = {
     "LV_UPDATE_NODE_EDITING_TEXT",
     "LV_UPDATE_POSITION",
   ],
-  VERTRIEB: [
+  VERTRIEB_BAULEITUNG: [
     "LV_CATALOG_CREATE",
     "LV_ADD_STRUCTURE_NODE",
     "LV_ADD_POSITION",
@@ -135,7 +135,7 @@ export class AuthorizationService {
   constructor(private readonly repos: InMemoryRepositories) {}
 
   public assertCanCreateOfferVersion(role: UserRole): void {
-    if (!new Set<UserRole>(["ADMIN", "VERTRIEB"]).has(role)) {
+    if (!new Set<UserRole>(["ADMIN", "VERTRIEB_BAULEITUNG"]).has(role)) {
       throw new DomainError("AUTH_ROLE_FORBIDDEN", "Keine Berechtigung fuer Angebotsversion", 403);
     }
   }
@@ -162,7 +162,7 @@ export class AuthorizationService {
   }
 
   public assertCanReadPaymentTerms(role: UserRole): void {
-    if (!new Set<UserRole>(["ADMIN", "GESCHAEFTSFUEHRUNG", "BUCHHALTUNG", "VERTRIEB", "VIEWER"]).has(role)) {
+    if (!new Set<UserRole>(["ADMIN", "GESCHAEFTSFUEHRUNG", "BUCHHALTUNG", "VERTRIEB_BAULEITUNG", "VIEWER"]).has(role)) {
       throw new DomainError("AUTH_ROLE_FORBIDDEN", "Keine Berechtigung zum Lesen der Zahlungsbedingungen", 403);
     }
   }
@@ -174,7 +174,7 @@ export class AuthorizationService {
   }
 
   public assertCanReadInvoice(role: UserRole): void {
-    if (!new Set<UserRole>(["ADMIN", "GESCHAEFTSFUEHRUNG", "BUCHHALTUNG", "VERTRIEB", "VIEWER"]).has(role)) {
+    if (!new Set<UserRole>(["ADMIN", "GESCHAEFTSFUEHRUNG", "BUCHHALTUNG", "VERTRIEB_BAULEITUNG", "VIEWER"]).has(role)) {
       throw new DomainError("AUTH_ROLE_FORBIDDEN", "Keine Berechtigung fuer Rechnung", 403);
     }
   }

--- a/src/services/user-account-service.ts
+++ b/src/services/user-account-service.ts
@@ -8,13 +8,14 @@ import type { AuditService } from "./audit-service.js";
 
 const BCRYPT_COST = 12;
 
-const ROLE_SET = new Set<UserRole>(["ADMIN", "BUCHHALTUNG", "GESCHAEFTSFUEHRUNG", "VERTRIEB", "VIEWER"]);
+const ROLE_SET = new Set<UserRole>(["ADMIN", "BUCHHALTUNG", "GESCHAEFTSFUEHRUNG", "VERTRIEB_BAULEITUNG", "VIEWER"]);
 
 function assertRole(value: string): UserRole {
-  if (!ROLE_SET.has(value as UserRole)) {
+  const normalized = value === "VERTRIEB" ? "VERTRIEB_BAULEITUNG" : value;
+  if (!ROLE_SET.has(normalized as UserRole)) {
     throw new DomainError("VALIDATION_FAILED", `Ungültige Rolle: ${value}`, 400);
   }
-  return value as UserRole;
+  return normalized as UserRole;
 }
 
 export type TenantUserListItem = {

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -211,7 +211,7 @@ export const loginRequestSchema = z.object({
   password: z.string().min(1).max(2000),
 });
 
-const userRoleEnum = z.enum(["ADMIN", "BUCHHALTUNG", "GESCHAEFTSFUEHRUNG", "VERTRIEB", "VIEWER"]);
+const userRoleEnum = z.enum(["ADMIN", "BUCHHALTUNG", "GESCHAEFTSFUEHRUNG", "VERTRIEB_BAULEITUNG", "VIEWER"]);
 
 export const createTenantUserSchema = z.object({
   email: authEmailInputSchema,

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -10,7 +10,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
   let app: FastifyInstance;
   const userId = "77777777-7777-4777-8777-777777777777";
   const buildHeaders = (
-    role: "ADMIN" | "BUCHHALTUNG" | "GESCHAEFTSFUEHRUNG" | "VERTRIEB" | "VIEWER" = "ADMIN",
+    role: "ADMIN" | "BUCHHALTUNG" | "GESCHAEFTSFUEHRUNG" | "VERTRIEB_BAULEITUNG" | "VIEWER" = "ADMIN",
     tenantId: string = SEED_IDS.tenantId,
   ) => {
     const token = createSignedToken({
@@ -281,7 +281,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     const response = await app.inject({
       method: "POST",
       url: "/exports",
-      headers: buildHeaders("VERTRIEB"),
+      headers: buildHeaders("VERTRIEB_BAULEITUNG"),
       payload: {
         entityType: "INVOICE",
         entityId: SEED_IDS.invoiceId,
@@ -326,7 +326,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     const response = await app.inject({
       method: "GET",
       url: `/documents/${SEED_IDS.offerVersionId}/allowed-actions?entityType=OFFER_VERSION`,
-      headers: buildHeaders("VERTRIEB"),
+      headers: buildHeaders("VERTRIEB_BAULEITUNG"),
     });
     expect(response.statusCode).toBe(200);
     const body = response.json();
@@ -447,7 +447,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     const allowed = await app.inject({
       method: "GET",
       url: `/documents/${SEED_IDS.offerVersionId}/allowed-actions?entityType=OFFER_VERSION`,
-      headers: buildHeaders("VERTRIEB"),
+      headers: buildHeaders("VERTRIEB_BAULEITUNG"),
     });
     expect(allowed.statusCode).toBe(200);
     expect(allowed.json().allowedActions).not.toContain("OFFER_CREATE_VERSION");
@@ -485,7 +485,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     const allowed = await app.inject({
       method: "GET",
       url: `/documents/${SEED_IDS.offerVersionId}/allowed-actions?entityType=OFFER_VERSION`,
-      headers: buildHeaders("VERTRIEB"),
+      headers: buildHeaders("VERTRIEB_BAULEITUNG"),
     });
     expect(allowed.statusCode).toBe(200);
     expect(allowed.json().allowedActions).not.toContain("OFFER_CREATE_VERSION");
@@ -521,7 +521,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     const allowed = await app.inject({
       method: "GET",
       url: `/documents/${SEED_IDS.offerVersionId}/allowed-actions?entityType=OFFER_VERSION`,
-      headers: buildHeaders("VERTRIEB"),
+      headers: buildHeaders("VERTRIEB_BAULEITUNG"),
     });
     expect(allowed.statusCode).toBe(200);
     expect(allowed.json().allowedActions).not.toContain("OFFER_CREATE_VERSION");
@@ -554,7 +554,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     expect(accepted.json().status).toBe("ANGENOMMEN");
   });
 
-  it("P0: SoT lists OFFER_CREATE_SUPPLEMENT after ANGENOMMEN for ADMIN, VERTRIEB, GESCHAEFTSFUEHRUNG", async () => {
+  it("P0: SoT lists OFFER_CREATE_SUPPLEMENT after ANGENOMMEN for ADMIN, VERTRIEB_BAULEITUNG, GESCHAEFTSFUEHRUNG", async () => {
     for (const nextStatus of ["IN_FREIGABE", "FREIGEGEBEN", "VERSENDET"] as const) {
       await app.inject({
         method: "POST",
@@ -577,7 +577,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
         reason: "Annahme fuer SoT Nachtrag",
       },
     });
-    for (const role of ["ADMIN", "VERTRIEB", "GESCHAEFTSFUEHRUNG"] as const) {
+    for (const role of ["ADMIN", "VERTRIEB_BAULEITUNG", "GESCHAEFTSFUEHRUNG"] as const) {
       const r = await app.inject({
         method: "GET",
         url: `/documents/${SEED_IDS.offerVersionId}/allowed-actions?entityType=OFFER_VERSION`,
@@ -785,7 +785,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     const versendet = await app.inject({
       method: "POST",
       url: "/supplements/status",
-      headers: buildHeaders("VERTRIEB"),
+      headers: buildHeaders("VERTRIEB_BAULEITUNG"),
       payload: { supplementVersionId, nextStatus: "VERSENDET", reason: "P0 transition" },
     });
     expect(versendet.statusCode).toBe(200);
@@ -805,7 +805,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     const transitions = [
       { nextStatus: "IN_FREIGABE", role: "ADMIN" as const },
       { nextStatus: "FREIGEGEBEN", role: "GESCHAEFTSFUEHRUNG" as const },
-      { nextStatus: "VERSENDET", role: "VERTRIEB" as const },
+      { nextStatus: "VERSENDET", role: "VERTRIEB_BAULEITUNG" as const },
     ];
     for (const t of transitions) {
       const r = await app.inject({
@@ -1021,7 +1021,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     const allowedVertrieb = await app.inject({
       method: "GET",
       url: `/documents/${supplementVersionId}/allowed-actions?entityType=SUPPLEMENT_VERSION`,
-      headers: buildHeaders("VERTRIEB"),
+      headers: buildHeaders("VERTRIEB_BAULEITUNG"),
     });
     expect(allowedVertrieb.statusCode).toBe(200);
     expect(allowedVertrieb.json().allowedActions).toContain("SUPPLEMENT_SET_IN_FREIGABE");
@@ -1079,7 +1079,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     await app.inject({
       method: "POST",
       url: "/supplements/status",
-      headers: buildHeaders("VERTRIEB"),
+      headers: buildHeaders("VERTRIEB_BAULEITUNG"),
       payload: { supplementVersionId, nextStatus: "VERSENDET", reason: "to VERSENDET" },
     });
     await checkActions("VERSENDET", ["SUPPLEMENT_SET_BEAUFTRAGT", "SUPPLEMENT_SET_ABGELEHNT"], "SUPPLEMENT_SET_IN_FREIGABE");
@@ -1150,7 +1150,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     const blockedExport = await app.inject({
       method: "POST",
       url: "/exports",
-      headers: buildHeaders("VERTRIEB"),
+      headers: buildHeaders("VERTRIEB_BAULEITUNG"),
       payload: { entityType: "SUPPLEMENT_VERSION", entityId: supplementVersionId, format: "GAEB" },
     });
     expect(blockedExport.statusCode).toBe(422);
@@ -1171,7 +1171,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     const releasedExport = await app.inject({
       method: "POST",
       url: "/exports",
-      headers: buildHeaders("VERTRIEB"),
+      headers: buildHeaders("VERTRIEB_BAULEITUNG"),
       payload: { entityType: "SUPPLEMENT_VERSION", entityId: supplementVersionId, format: "GAEB" },
     });
     expect(releasedExport.statusCode).toBe(201);
@@ -1192,7 +1192,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     const allowed = await app.inject({
       method: "GET",
       url: `/documents/${SEED_IDS.offerVersionId}/allowed-actions?entityType=OFFER_VERSION`,
-      headers: buildHeaders("VERTRIEB"),
+      headers: buildHeaders("VERTRIEB_BAULEITUNG"),
     });
     expect(allowed.statusCode).toBe(200);
     expect(allowed.json().allowedActions).toContain("OFFER_CREATE_VERSION");
@@ -1200,7 +1200,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
     const create = await app.inject({
       method: "POST",
       url: "/offers/version",
-      headers: buildHeaders("VERTRIEB"),
+      headers: buildHeaders("VERTRIEB_BAULEITUNG"),
       payload: {
         offerId: SEED_IDS.offerId,
         lvVersionId: SEED_IDS.lvVersionId,
@@ -1270,7 +1270,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const created = await app.inject({
         method: "POST",
         url: "/measurements",
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           projectId,
           customerId,
@@ -1292,7 +1292,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       expect(events.some((e) => e.entityId === measurementVersionId && e.action === "VERSION_CREATED")).toBe(true);
 
       for (const [role, next] of [
-        ["VERTRIEB", "GEPRUEFT"],
+        ["VERTRIEB_BAULEITUNG", "GEPRUEFT"],
         ["GESCHAEFTSFUEHRUNG", "FREIGEGEBEN"],
         ["BUCHHALTUNG", "ABGERECHNET"],
         ["GESCHAEFTSFUEHRUNG", "ARCHIVIERT"],
@@ -1337,7 +1337,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const created = await app.inject({
         method: "POST",
         url: "/measurements",
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           projectId,
           customerId,
@@ -1350,7 +1350,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       await app.inject({
         method: "POST",
         url: "/measurements/status",
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           measurementVersionId,
           nextStatus: "GEPRUEFT",
@@ -1370,7 +1370,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const blocked = await app.inject({
         method: "POST",
         url: `/measurements/${measurementVersionId}/positions`,
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           positions: [{ lvPositionId: posId, quantity: 99, unit: "m" }],
           reason: "P2-M-03 must fail",
@@ -1387,7 +1387,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const created = await app.inject({
         method: "POST",
         url: "/measurements",
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           projectId,
           customerId,
@@ -1400,7 +1400,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const ver = await app.inject({
         method: "POST",
         url: "/measurements/version",
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: { measurementId, reason: "P2-M-04 must be forbidden" },
       });
       expect(ver.statusCode).toBe(409);
@@ -1422,7 +1422,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const created = await app.inject({
         method: "POST",
         url: "/measurements",
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           projectId,
           customerId,
@@ -1451,7 +1451,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const created = await app.inject({
         method: "POST",
         url: "/measurements",
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           projectId,
           customerId,
@@ -1465,7 +1465,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
         measurementVersionId: string;
       };
       for (const [role, next] of [
-        ["VERTRIEB", "GEPRUEFT"],
+        ["VERTRIEB_BAULEITUNG", "GEPRUEFT"],
         ["GESCHAEFTSFUEHRUNG", "FREIGEGEBEN"],
       ] as const) {
         await app.inject({
@@ -1478,7 +1478,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const v2res = await app.inject({
         method: "POST",
         url: "/measurements/version",
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: { measurementId, reason: "P2-M-06 neue Version" },
       });
       expect(v2res.statusCode).toBe(201);
@@ -1536,7 +1536,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const before = await app.inject({
         method: "PATCH",
         url: `/lv/positions/${samplePositionId}`,
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: { editingText: "Kundenfreundlich", reason: "Nur Bearbeitungstext" },
       });
       expect(before.statusCode).toBe(200);
@@ -1549,7 +1549,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const res = await app.inject({
         method: "PATCH",
         url: `/lv/positions/${samplePositionId}`,
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           editingText: "Ok",
           systemText: "Illegal",
@@ -1565,7 +1565,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const res = await app.inject({
         method: "PATCH",
         url: `/lv/positions/${samplePositionId}`,
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           editingText: "Ok",
           reason: "Strict body shape",
@@ -1581,7 +1581,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const posProbe = await app.inject({
         method: "PATCH",
         url: `/lv/positions/${samplePositionId}`,
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: { editingText: "Probe", reason: "Resolve parent node id" },
       });
       expect(posProbe.statusCode).toBe(200);
@@ -1589,7 +1589,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const res = await app.inject({
         method: "PATCH",
         url: `/lv/nodes/${nodeId}/editing-text`,
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           editingText: "Knoten-Ed",
           reason: "Strict body shape",
@@ -1605,14 +1605,14 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const posProbe = await app.inject({
         method: "PATCH",
         url: `/lv/positions/${samplePositionId}`,
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: { editingText: "Probe2", reason: "Resolve parent node id" },
       });
       const nodeId = posProbe.json().parentNodeId as string;
       const res = await app.inject({
         method: "PATCH",
         url: `/lv/nodes/${nodeId}/editing-text`,
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           editingText: "X",
           systemText: "No",
@@ -1628,7 +1628,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const res = await app.inject({
         method: "PATCH",
         url: `/lv/positions/${samplePositionId}`,
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           editingText: "Ok",
           systemText: "Illegal",
@@ -1662,7 +1662,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const res = await app.inject({
         method: "POST",
         url: `/lv/versions/${SEED_IDS.lvVersionId}/nodes`,
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
         payload: {
           parentNodeId: null,
           kind: "BEREICH",
@@ -1701,7 +1701,7 @@ describe("ERP domain slice (Teil I Domäne)", () => {
       const sotNew = await app.inject({
         method: "GET",
         url: `/documents/${v2}/allowed-actions?entityType=LV_VERSION`,
-        headers: buildHeaders("VERTRIEB"),
+        headers: buildHeaders("VERTRIEB_BAULEITUNG"),
       });
       expect(sotNew.json().allowedActions).toContain("LV_ADD_POSITION");
     });

--- a/test/auth-token-secret.test.ts
+++ b/test/auth-token-secret.test.ts
@@ -3,6 +3,7 @@ import {
   assertAuthTokenSecretConfiguredAtStartup,
   createSignedToken,
   getAuthTokenSecret,
+  verifyBearerToken,
 } from "../src/auth/token-auth.js";
 
 describe("AUTH_TOKEN_SECRET bootstrap (SEC-01 / PWA-SEC-P0-001)", () => {
@@ -23,6 +24,21 @@ describe("AUTH_TOKEN_SECRET bootstrap (SEC-01 / PWA-SEC-P0-001)", () => {
       exp: Math.floor(Date.now() / 1000) + 600,
     });
     expect(token.startsWith("v1.")).toBe(true);
+  });
+
+  it("akzeptiert Legacy-Claim VERTRIEB und liefert VERTRIEB_BAULEITUNG", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("AUTH_TOKEN_SECRET", "");
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    const token = createSignedToken({
+      sub: "77777777-7777-4777-8777-777777777777",
+      tenantId: "11111111-1111-4111-8111-111111111111",
+      // @ts-expect-error — absichtlich Legacy-String im signierten Payload
+      role: "VERTRIEB",
+      exp,
+    });
+    const auth = verifyBearerToken(`Bearer ${token}`);
+    expect(auth.role).toBe("VERTRIEB_BAULEITUNG");
   });
 
   it("refuses non-test runtime without secret and without insecure opt-in", () => {

--- a/test/persistence.integration.test.ts
+++ b/test/persistence.integration.test.ts
@@ -225,7 +225,7 @@ persistenceDbSuite("Persistence Inkrement 2 (Postgres; in CI ohne SKIP)", () => 
       payload: {
         email,
         password: "initial-pass-12",
-        role: "VERTRIEB",
+        role: "VERTRIEB_BAULEITUNG",
         reason: "Integrationstest Passwort-Reset",
       },
     });


### PR DESCRIPTION
## Summary
- Migriert `users.role` von `VERTRIEB` → `VERTRIEB_BAULEITUNG`.
- Normalisiert Legacy-DB-Rolle und JWT-Claim `VERTRIEB` zu `VERTRIEB_BAULEITUNG` (abwärtskompatibel).
- Passt Auth/Login, Rollen-Enums/Validierung und Tests an.
- Lokal-Workflow: `verify:ci:local-db` defaultet auf Compose-Port `5432`.

## Test plan
- `npm run verify:ci:local-db`