### PR TITLE
chore(ci): Dependabot Prisma-Gruppe + Ticket PRISMA-7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,17 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     groups:
+      prisma:
+        patterns:
+          - "prisma"
+          - "@prisma/*"
       dev-dependencies:
         dependency-type: development
         patterns:
           - "*"
+        exclude-patterns:
+          - "prisma"
+          - "@prisma/*"
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/docs/tickets/PRISMA-7-UPGRADE.md
+++ b/docs/tickets/PRISMA-7-UPGRADE.md
@@ -1,0 +1,32 @@
+# PRISMA-7-UPGRADE — geplantes Major-Upgrade (eigenes Inkrement)
+
+## Kontext
+
+Dependabot-PRs für nur `@prisma/client` oder nur `prisma` führen zu einem **Versions-Split** und brechen `npm ci` / `postinstall` (`prisma generate`). Abgeschlossenes Beispiel: PR#14 (geschlossen). Künftig gruppiert [`.github/dependabot.yml`](../../.github/dependabot.yml) Prisma-Pakete in einem gemeinsamen PR.
+
+Dieses Ticket beschreibt die **bewusste** Migration auf Prisma 7.x — nicht mergen, bevor alle Punkte erfüllt sind.
+
+## Zielversion
+
+- Zum Umsetzungszeitpunkt: aktuelle **stabile 7.x**-Releases von `prisma` und `@prisma/client` wählen (Release Notes lesen).
+- **Pflicht:** `prisma` (devDependency) und `@prisma/client` (dependency) auf **dieselbe** Version pinnen bzw. identisches semver-Range, sodass `package-lock.json` **keine** gemischten `@prisma/*`-Major-Versionen enthält.
+
+## Voraussetzungen
+
+- **Node:** Prisma 7 fordert u.a. `^20.19 || ^22.12 || >=24.0` für den Client — CI nutzt Node 22 (siehe [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)); vor Upgrade Mindestversion mit [Prisma-Doku](https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions) abgleichen.
+- **PostgreSQL:** Weiterhin dieselbe Test-DB wie in CI (Postgres 16, `migrate deploy`).
+
+## Checkliste Umsetzung
+
+1. Offizielles Upgrade-Guide durcharbeiten: [Upgrading versions](https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions).
+2. `package.json`: `prisma` und `@prisma/client` gemeinsam anheben; `npm install` / Lockfile konsistent erzeugen.
+3. [`prisma/schema.prisma`](../../prisma/schema.prisma) und ggf. neue Konfigurationsdateien (je nach 7.x-Anforderungen) anpassen.
+4. Lokal: `npx prisma generate`, `npx prisma migrate deploy` gegen Test-DB.
+5. Verifikation: `npm run typecheck`, `npm test`, `npm run test -w apps/web`, idealerweise `npm run verify:ci:local-db` (siehe Root-[`package.json`](../../package.json)).
+6. CI grün: Job `backend` in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) (inkl. Persistenz-Suite mit `PERSISTENCE_DB_TEST_URL`).
+
+## Definition of Done
+
+- Kein halbes Upgrade: alle direkten und relevanten transitive `@prisma/*`-Versionen im Lockfile passen zur gewählten 7.x.
+- `npm ci` inkl. `postinstall` / `prisma generate` erfolgreich.
+- Alle obigen Tests und CI-Schritte grün.


### PR DESCRIPTION
## Inhalt

- **Dependabot:** Neue Gruppe `prisma` mit Patterns `prisma` und `@prisma/*`, damit `prisma` (CLI) und `@prisma/client` in **einem** Versions-Update-PR landen und kein halbes Major-Upgrade mehr entsteht (Kontext: geschlossenes PR#14).
- **dev-dependencies:** `exclude-patterns` für `prisma` und `@prisma/*`, damit Prisma nicht in die wöchentliche Dev-Sammel-PR rutscht.
- **Dokumentation:** `docs/tickets/PRISMA-7-UPGRADE.md` als geplantes eigenes Inkrement mit Checkliste und Verweis auf CI/Verify.

## Hinweis

PR#14 wurde bereits auf GitHub geschlossen; dieser PR liefert nur Repo-Änderungen dazu.

Made with [Cursor](https://cursor.com)