### PR TITLE
docs: Merge-Pflicht backend + e2e-smoke (Runbook + Plan)

### DIFF
--- a/docs/plans/nächste-schritte.md
+++ b/docs/plans/nächste-schritte.md
@@ -62,8 +62,12 @@ Dieses Dokument wird nach jedem abgeschlossenen Entwicklungsschritt aktualisiert
 
 ### Noch offen (für Schritt 4)
 
-- **Playwright-Rauchtest** „Login → Finanz“ ist auf **`main`** in CI (`e2e-smoke`); optional als **Pflicht-Check** in Branch Protection ergänzen (Runbook).
+- **Playwright-Rauchtest** „Login → Finanz“ (`e2e-smoke`): seit **2026-04-25** in GitHub Ruleset **merge-pflichtig** neben **`backend`** (Repo `rhermann90/ERP`, Ruleset „branch protection“). Nachweis und Team-Vorlage: [`docs/runbooks/github-branch-protection-backend.md`](../runbooks/github-branch-protection-backend.md).
 - Optional **Lesepfade** in der **Haupt-Shell** weiter ausbauen (z. B. weitere `GET`-Details wie `GET /offer-versions/...`).
+
+### Merge-Evidenz `main` (operativ, 2026-04-25)
+
+- **Pflicht-Checks:** `backend`, `e2e-smoke` (beide grün erforderlich). Kurzmeldung an QA/Team: Abschnitt „Team / QA — Kurzmeldung“ im Runbook [`github-branch-protection-backend.md`](../runbooks/github-branch-protection-backend.md).
 
 ### Schritt 4 — Status
 
@@ -77,9 +81,25 @@ Dieses Dokument wird nach jedem abgeschlossenen Entwicklungsschritt aktualisiert
 
 ## Nächster Schritt (Empfehlung)
 
-1. **WIP-Branch aufteilen:** `feat/wip-recovery-from-stash-2026-04-21` enthält viele Themen — in **2–3 fokussierte PRs** nach `main` splitten (z. B. Migration `VERTRIEB_BAULEITUNG` + Auth; UI `RoleQuickNav`/Mapping; verbleibende Doku/Contracts), jeweils mit `verify:ci` / bei DB `verify:ci:local-db`.
-2. **FIN-2 starten (kleinster Slice):** Gate ist frei (`FIN-2-START-GATE.md`); erster PR nur **eine** klar umrissene Backend-Funktion laut **ADR-0007** (kein „alles auf einmal“).
+1. **PR-Hygiene:** Thematisch getrennte PRs; je PR `npm run verify:ci`, bei Persistenz `npm run verify:ci:local-db` (Compose-Host **15432**) — siehe [`docs/runbook/ci-and-persistence-tests.md`](../runbook/ci-and-persistence-tests.md). Legacy-WIP-Branch `feat/wip-recovery-from-stash-2026-04-21` nur noch splitten, falls fachlich offene Commits darauf liegen; `main` ist Integrationslinie.
+2. **PL-Inkrement (Default Wave3 Option A):** PWA Finanz-Vorbereitung (Tabs, **OFF/SEMI** + SEMI-Kontext, [ADR-0011](../adr/0011-fin4-semi-dunning-context.md)); **Cron/AUTO** entfernt — siehe [`NEXT-INCREMENT-FINANCE-WAVE3.md`](../tickets/NEXT-INCREMENT-FINANCE-WAVE3.md). **Operativ:** thematischer PR mit `npm run verify:ci` und bei Persistenz-Touch `npm run verify:ci:local-db` ([Runbook](../runbook/ci-and-persistence-tests.md)); Vitest für `PATCH /finance/dunning-reminder-automation` und lokale Validierung in [`apps/web/src/components/FinancePreparation.test.tsx`](../../apps/web/src/components/FinancePreparation.test.tsx). **Nicht** parallel **8.4(2–6)** oder **Pfad C** (Zwischenstatus-Rechnung) ohne explizites PL-/ADR-Gate.
+
+### PL-Entscheid PWA Finanz-Vorbereitung (2026-04-25)
+
+- **IA:** Tabs innerhalb `#/finanz-vorbereitung` — **keine** Unter-Hash-Routen (`#/finanz-vorbereitung/…`); Begründung: ein Hash für Lesezeichen/E2E, weniger Router-Aufwand.
+- **SEMI-Kontext:** Zeitzone / optional Bundesland / Kalender- vs. Werktage / Kanal-Vorgabe in der Automation-PATCH-UI; fachliche und steuerliche Klärung mit PL ([ADR 0010](../adr/0010-fin4-m4-dunning-email-and-templates.md), [ADR 0011](../adr/0011-fin4-semi-dunning-context.md)).
+3. **Review / Merge-Evidenz:** Bei Finanz-PRs [`docs/contracts/review-checklist-finanz-pr.md`](../contracts/review-checklist-finanz-pr.md); vor Merge §5a in [`docs/contracts/qa-fin-0-gate-readiness.md`](../contracts/qa-fin-0-gate-readiness.md) (grüner Remote-Job **`backend`** zum PR-Head).
+
+**Kürzlich abgesichert (QA 2026-04-25):** FIN-1 M1-DoD mit Postgres — `it("FIN-1 M1: zwei Zahlungsbedingungs-Versionen; …")` in [`test/persistence.integration.test.ts`](../../test/persistence.integration.test.ts); Evidenzzeile in [`docs/PHASENARBEITSPLAN-MVP-V1.3-FINANZ.md`](../PHASENARBEITSPLAN-MVP-V1.3-FINANZ.md) Abschnitt E1.
+
+**Kürzlich abgesichert (PWA 2026-04-26):** Finanz-Vorbereitung — `FinancePreparation.test.tsx`: erfolgreicher Mandanten-Automation-PATCH inkl. Zeitzone/Kalender-Werktage/Kanal/Bundesland; lokale Fehlerpfade ohne API-Call bei zu kurzem Grund oder einstelligem Bundesland. **`generated/prisma`:** nicht versionieren (Root-`.gitignore`); Runbook-Hinweis unter „PR-Checkliste (Persistenz / Schema)“ in [`ci-and-persistence-tests.md`](../runbook/ci-and-persistence-tests.md). **e2e-smoke** ist seit **2026-04-25** als zweiter Pflicht-Statuscheck aktiv ([`github-branch-protection-backend.md`](../runbooks/github-branch-protection-backend.md)).
 
 ## Danach in Aussicht
 
 - Produktionsnahe Mandanten-Policies (Kalkulation/Disposition exakt zuordnen) und erweiterte Rollen, falls das Backend mehr als fünf API-Rollen erhält.
+
+### PWA / Finanz-Backlog (eigene PRs, nicht gemischt)
+
+- **B5 formales Mahn-PDF:** PWA später nur Anzeige/Download/Link — [`docs/tickets/B5-FORMAL-DUNNING-PDF.md`](../tickets/B5-FORMAL-DUNNING-PDF.md).
+- **Skonto-UI:** optional nach API-First / PL — Non-Goal-Hinweis in [`docs/tickets/NEXT-INCREMENT-FINANCE-WAVE3.md`](../tickets/NEXT-INCREMENT-FINANCE-WAVE3.md).
+- **Haupt-Shell:** weitere read-only `GET`-Details (z. B. `GET /offer-versions/…`) — siehe offenen Punkt oben in Schritt 4.

--- a/docs/runbooks/github-branch-protection-backend.md
+++ b/docs/runbooks/github-branch-protection-backend.md
@@ -8,7 +8,7 @@
 2. **Target branches:** `main` (ggf. `master` analog).
 3. **Require status checks to pass** aktivieren.
 4. **Status checks** hinzufügen: den Check-Namen exakt wie in GitHub Actions angezeigt — typisch **`backend`** (Name des Jobs in `ci.yml`).
-5. Optional (wenn das Team UI-Regressionen mit-merge-blockieren will): zweiten Check **`e2e-smoke`** hinzufügen (Playwright-Rauchtest aus demselben Workflow). Standard bleibt **nur `backend`** als Pflicht; `e2e-smoke` läuft dann dennoch nach jedem grünen `backend` und warnt sichtbar bei Rot.
+5. Optional bzw. Team-Entscheid: zweiten Check **`e2e-smoke`** (Playwright-Rauchtest, derselbe Workflow). **Stand Repo `rhermann90/ERP` (2026-04-25):** Ruleset verlangt **`backend`** und **`e2e-smoke`**. Vorher galt nur `backend` als Pflicht; `e2e-smoke` lief mit und warnte. **Nach Aktivierung als Pflicht:** Team/QA informieren; Status in [`docs/plans/nächste-schritte.md`](../plans/nächste-schritte.md) Schritt 4 spiegeln.
 6. Optional: **Require branches to be up to date before merging** (Team-Entscheidung).
 7. Speichern; Test-PR mit absichtlich rotem Step → Merge sollte blockieren.
 
@@ -22,3 +22,38 @@
 - Ohne Org-Rechte: Ticket an Admin mit Verweis auf diese Datei und auf **QA**-Pflicht §5a in `qa-fin-0-gate-readiness.md`.
 
 **Ersetzt nicht:** menschliche Code-Reviews oder PL-Gates (`FIN-2-START-GATE.md`).
+
+## Projektleitung / QA: Nachweis zur Pflicht für `e2e-smoke`
+
+**Aktuell (siehe Tabelle unten):** Merge auf Default-Branch ist nur bei grünem **`backend`** und grünem **`e2e-smoke`** möglich (Ruleset „branch protection“).
+
+Wenn die Branch-Protection auf **zwei Pflicht-Checks** (`backend` + `e2e-smoke`) umgestellt **oder zurück** auf nur `backend` gestellt wird:
+
+1. Datum und Kurzbegründung in Release-Notes, PR-Diskussion oder unten als eine Zeile eintragen.
+2. QA explizit informieren: bei **Aktivierung** von `e2e-smoke` als Pflicht ist Merge ohne grünen E2E ausgeschlossen; bei **Rücknahme** auf nur `backend` das Gegenteil kommunizieren (Vorlage unten ggf. anpassen).
+3. In [`docs/plans/nächste-schritte.md`](../plans/nächste-schritte.md) (Schritt 4) den operativen Status kurz spiegeln, damit Plan und Runbook übereinstimmen.
+
+| Datum      | `e2e-smoke` als Merge-Pflicht | Referenz (PR/Notiz) |
+|------------|-------------------------------|---------------------|
+| 2026-04-25 | ja                            | Ruleset `branch protection` (ID 15256596): `gh api repos/rhermann90/ERP/rulesets/15256596 -X PUT` mit `required_status_checks` für `backend` + `e2e-smoke` (GitHub Actions `integration_id` 15368). |
+
+### Team / QA — Kurzmeldung (copy-paste)
+
+```text
+Merge auf main: ab sofort blockiert, wenn einer der beiden CI-Checks fehlschlägt:
+• backend (wie bisher)
+• e2e-smoke (Playwright „Login → Finanz“, u. a. Tab „Grundeinstellungen Mahnlauf“)
+Details: docs/runbooks/github-branch-protection-backend.md
+```
+
+### GitHub CLI — Ruleset mit zwei Pflicht-Checks (Referenz)
+
+Klassische `branches/main/protection` liefert bei Rulesets oft 404; stattdessen Ruleset per ID lesen/schreiben:
+
+```bash
+gh api repos/<org>/<repo>/rulesets --jq '.[] | {id, name}'
+gh api repos/<org>/<repo>/rulesets/<RULESET_ID> | jq .
+# PUT-Body: JSON mit rules[].type == required_status_checks und
+# parameters.required_status_checks: [ { context, integration_id }, … ]
+# integration_id 15368 = GitHub Actions (typisch für Workflow-Jobs).
+```


### PR DESCRIPTION
## Inhalt

- `docs/runbooks/github-branch-protection-backend.md`: aktiver Stand (Ruleset mit `backend` + `e2e-smoke`), Tabelle, Team-Kurzmeldung, CLI-Referenz
- `docs/plans/nächste-schritte.md`: Schritt 4 / operative Merge-Evidenz gespiegelt

## Hinweis

GitHub Ruleset ist bereits aktiv; diese PR bringt nur die Doku auf `main`. Siehe auch Issue #38.

Nach Merge: lokal `git checkout main && git pull` (dein WIP bleibt als geänderte Dateien erhalten).

Made with [Cursor](https://cursor.com)