### PR TITLE
test(e2e): Finanz-Smoke — SoT Fortgeschritten (Preset + allowed-actions)

### DIFF
--- a/e2e/login-finance-smoke.spec.ts
+++ b/e2e/login-finance-smoke.spec.ts
@@ -31,5 +31,11 @@ test.describe("Login → Finanz (Vorbereitung)", () => {
     await expect(page.getByRole("heading", { name: /SoT — erlaubte Aktionen \(Fortgeschritten\)/i })).toBeVisible({
       timeout: 10_000,
     });
+
+    await page.getByRole("button", { name: "Voreinstellung: Angebotsversion" }).click();
+    await expect(page.getByLabel("entityType für allowed-actions")).toHaveValue("OFFER_VERSION");
+
+    await page.getByRole("button", { name: "Erlaubte Aktionen laden" }).click();
+    await expect(page.getByText("Rohantwort allowed-actions (JSON)", { exact: true })).toBeVisible({ timeout: 15_000 });
   });
 });


### PR DESCRIPTION
## Summary

Single-Agent / Track 1: Erweitert [`e2e/login-finance-smoke.spec.ts`](e2e/login-finance-smoke.spec.ts) um eine minimale **Fortgeschritten**-Interaktion:

- Preset **Voreinstellung: Angebotsversion**
- Assert `entityType`-`select` = `OFFER_VERSION`
- **Erlaubte Aktionen laden** → sichtbare JSON-Zusammenfassung (`Rohantwort allowed-actions (JSON)`)

Keine API-/OpenAPI-Änderung.

## Verification

- `npx playwright test e2e/login-finance-smoke.spec.ts` — Exit 0
- `npm run verify:ci` — Exit 0

## Notes

- E2E nutzt weiterhin Dev-Auth (`ERP_LOGIN_ROLE=ADMIN` in Playwright webServer) wie bisher.

Made with [Cursor](https://cursor.com)