### PR TITLE
fix(web): Mahn-Grundeinstellungen — kanonischer Hash ohne ?tab=-Duplikat

### DIFF
--- a/apps/web/src/components/FinancePreparation.test.tsx
+++ b/apps/web/src/components/FinancePreparation.test.tsx
@@ -778,6 +778,7 @@ describe("hash-route — Finanz-Vorbereitung (Deep-Link)", () => {
   });
 
   it("financePrepHashWithTab", () => {
+    expect(financePrepHashWithTab("grundeinstellungen")).toBe("#/finanz-grundeinstellungen");
     expect(financePrepHashWithTab("fortgeschritten")).toBe("#/finanz-vorbereitung?tab=fortgeschritten");
   });
 

--- a/apps/web/src/components/finance/FinanceFeatureMatrix.tsx
+++ b/apps/web/src/components/finance/FinanceFeatureMatrix.tsx
@@ -37,7 +37,7 @@ export function FinanceFeatureMatrix() {
     },
     {
       area: "FIN-4 Mahn-Kandidaten / Automation (SEMI)",
-      inUi: "Tab Grundeinstellungen: GET/PATCH automation, GET candidates, Dry-Run/EXECUTE; Deep-Link `#/finanz-vorbereitung?tab=…` / `#/finanz-grundeinstellungen`",
+      inUi: "Tab Grundeinstellungen: GET/PATCH automation, GET candidates, Dry-Run/EXECUTE; Deep-Link kanonisch `#/finanz-grundeinstellungen`, sonst `#/finanz-vorbereitung?tab=…`",
       einordnung: "nicht Zielprodukt (M4)",
       hinweis: "ADR-0011 B3 (stageDeadlineIso, eligibilityContext); kein Cron/AUTO; bei Server-OFF sind Mahnlauf-Dry-Run/EXECUTE und Batch-E-Mail (5c) in der PWA deaktiviert (Variante 1a); keine Offline-Schreibsimulation.",
     },

--- a/apps/web/src/lib/hash-route.test.ts
+++ b/apps/web/src/lib/hash-route.test.ts
@@ -1,20 +1,33 @@
 import { describe, expect, it } from "vitest";
-import { financePrepHashWithTab, normalizeFinancePrepHashToCanon } from "./hash-route.js";
+import {
+  FINANCE_PREP_GRUNDEINSTELLUNGEN_HASH,
+  financePrepHashWithTab,
+  normalizeFinancePrepHashToCanon,
+} from "./hash-route.js";
 
-describe("normalizeFinancePrepHashToCanon", () => {
-  it("ersetzt Alias #/finanz-grundeinstellungen durch kanonischen Tab-Hash", () => {
-    window.history.replaceState(null, "", "/");
-    window.location.hash = "#/finanz-grundeinstellungen";
-    normalizeFinancePrepHashToCanon();
-    expect(window.location.hash).toBe(financePrepHashWithTab("grundeinstellungen"));
+describe("financePrepHashWithTab", () => {
+  it("nutzt dedizierten Pfad für Grundeinstellungen", () => {
+    expect(financePrepHashWithTab("grundeinstellungen")).toBe(FINANCE_PREP_GRUNDEINSTELLUNGEN_HASH);
   });
 
-  it("lässt bereits kanonischen Grundeinstellungen-Hash unverändert", () => {
+  it("nutzt vorbereitung-Query für andere Tabs", () => {
+    expect(financePrepHashWithTab("rechnung")).toBe("#/finanz-vorbereitung?tab=rechnung");
+  });
+});
+
+describe("normalizeFinancePrepHashToCanon", () => {
+  it("vereinheitlicht ?tab=grundeinstellungen auf dedizierten Pfad", () => {
     window.history.replaceState(null, "", "/");
-    const canon = financePrepHashWithTab("grundeinstellungen");
-    window.location.hash = canon;
+    window.location.hash = "#/finanz-vorbereitung?tab=grundeinstellungen";
     normalizeFinancePrepHashToCanon();
-    expect(window.location.hash).toBe(canon);
+    expect(window.location.hash).toBe(FINANCE_PREP_GRUNDEINSTELLUNGEN_HASH);
+  });
+
+  it("lässt dedizierten Grundeinstellungen-Pfad unverändert", () => {
+    window.history.replaceState(null, "", "/");
+    window.location.hash = FINANCE_PREP_GRUNDEINSTELLUNGEN_HASH;
+    normalizeFinancePrepHashToCanon();
+    expect(window.location.hash).toBe(FINANCE_PREP_GRUNDEINSTELLUNGEN_HASH);
   });
 
   it("greift nicht bei anderen Finanz-Vorbereitung-Pfaden ein", () => {

--- a/apps/web/src/lib/hash-route.ts
+++ b/apps/web/src/lib/hash-route.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 /** Hash-Route zur read-only Finanz-Vorbereitungsseite (ohne react-router). */
 export const FINANCE_PREP_HASH = "#/finanz-vorbereitung";
 
-/** Alias: öffnet Finanz-Vorbereitung direkt im Tab „Grundeinstellungen Mahnlauf“. */
+/** Kanonischer Deep-Link zum Tab „Grundeinstellungen Mahnlauf“ (ohne `?tab=`-Duplikat). */
 export const FINANCE_PREP_GRUNDEINSTELLUNGEN_HASH = "#/finanz-grundeinstellungen";
 
 export const LOGIN_HASH = "#/login";
@@ -45,8 +45,9 @@ export function resolveFinancePrepInitialMainTab(path: string, query: URLSearchP
   return "rechnung";
 }
 
-/** Kanonische Hash-Form inkl. Tab-Query (Lesezeichen / Tab-Wechsel in der PWA). */
+/** Kanonische Hash-Form (Lesezeichen / Tab-Wechsel). Tab „Grundeinstellungen“ = dedizierter Pfad. */
 export function financePrepHashWithTab(tab: FinancePrepMainTab): string {
+  if (tab === "grundeinstellungen") return FINANCE_PREP_GRUNDEINSTELLUNGEN_HASH;
   return `#/finanz-vorbereitung?tab=${tab}`;
 }
 
@@ -61,19 +62,23 @@ export function applyFinancePrepTabToLocationHash(tab: FinancePrepMainTab): void
 }
 
 /**
- * Kanonischer Lesezeichen-Pfad für Finanz-Vorbereitung inkl. Tab „Grundeinstellungen“:
- * `#/finanz-vorbereitung?tab=grundeinstellungen`. Alias `#/finanz-grundeinstellungen` wird
- * einmalig per replaceState umgestellt (kein doppelter Ladezustand in der PWA).
+ * Ein kanonischer Eintrag für „Grundeinstellungen Mahnlauf“: `#/finanz-grundeinstellungen`.
+ * Lesezeichen `#/finanz-vorbereitung?tab=grundeinstellungen` wird einmalig per replaceState
+ * dorthin vereinheitlicht (kein paralleles `?tab=` für dieselbe Ansicht).
  */
 export function normalizeFinancePrepHashToCanon(): void {
   const path = normalizeHash();
-  if (path !== "/finanz-grundeinstellungen") return;
-  const next = financePrepHashWithTab("grundeinstellungen");
-  if (window.location.hash !== next) {
-    const url = `${window.location.pathname}${window.location.search}${next}`;
-    history.replaceState(null, "", url);
-    window.dispatchEvent(new Event("hashchange"));
+  const q = readHashQuery();
+  if (path === "/finanz-vorbereitung" && q.get("tab")?.trim().toLowerCase() === "grundeinstellungen") {
+    const next = FINANCE_PREP_GRUNDEINSTELLUNGEN_HASH;
+    if (window.location.hash !== next) {
+      const url = `${window.location.pathname}${window.location.search}${next}`;
+      history.replaceState(null, "", url);
+      window.dispatchEvent(new Event("hashchange"));
+    }
+    return;
   }
+  if (path === "/finanz-grundeinstellungen") return;
 }
 
 export function useHashRoute(): string {

--- a/apps/web/src/lib/role-quick-actions.ts
+++ b/apps/web/src/lib/role-quick-actions.ts
@@ -24,7 +24,7 @@ const finance: QuickPreset = {
   id: "finance-prep",
   label: "Finanz-Vorbereitung",
   subtitle:
-    "Kanon #/finanz-vorbereitung?tab=… — Alias #/finanz-grundeinstellungen wird beim Laden auf ?tab=grundeinstellungen normalisiert",
+    "Tabs: #/finanz-vorbereitung?tab=… — Tab Grundeinstellungen kanonisch #/finanz-grundeinstellungen (ohne ?tab=-Duplikat)",
 };
 
 /** Direkt Tab „Grundeinstellungen Mahnlauf“ (Automation, Kandidaten, Mahnlauf). */
@@ -32,7 +32,7 @@ const financeGrundeinstellungen: QuickPreset = {
   kind: "finance",
   id: "finance-grundeinstellungen",
   label: "Mahn-Grundeinstellungen",
-  subtitle: "Shortcut #/finanz-grundeinstellungen → Kanon ?tab=grundeinstellungen beim ersten Paint",
+  subtitle: "Deep-Link #/finanz-grundeinstellungen (Mahn-Grundeinstellungen)",
 };
 
 const doc = (

--- a/docs/CODEMAPS/overview.md
+++ b/docs/CODEMAPS/overview.md
@@ -64,7 +64,7 @@ UI/UX-Leitfaden und Darstellungsmodi: [`docs/ui-ux-style-guide.md`](../ui-ux-sty
 | `src/lib/tenant-session.ts`, `token-payload.ts` | Mandanten-Session |
 | `src/lib/action-executor.ts`, `role-quick-actions.ts`, `v13-domain-role-mapping.ts` | Aktionen / Rollen |
 | `src/components/*.tsx` | UI (Shell, Login, Dokument-Texte, …) |
-| `src/lib/hash-route.ts`, `normalizeFinancePrepHashToCanon` in `App.tsx` | Finanz-Hash-Routing: Kanon `#/finanz-vorbereitung?tab=…`, Alias `#/finanz-grundeinstellungen` → einmalige Normalisierung per `replaceState`; `FINANCE_PREP_*` Konstanten |
+| `src/lib/hash-route.ts`, `normalizeFinancePrepHashToCanon` in `App.tsx` | Finanz-Hash-Routing: Tab „Grundeinstellungen“ kanonisch `#/finanz-grundeinstellungen`; andere Tabs `#/finanz-vorbereitung?tab=…`; `?tab=grundeinstellungen` per `replaceState` vereinheitlicht; `FINANCE_PREP_*` Konstanten |
 | `src/components/FinancePreparation.tsx`, `src/components/finance/FinancePreparation*Panel.tsx` | Finanz-Vorbereitung: Tabs inkl. Grundeinstellungen Mahnlauf; OFF/SEMI; OFF-1a (Batch-Buttons bei Server-OFF); SEMI-Kontext (ADR-0010 / ADR-0011) |
 | `vite.config.ts` | Build/Dev |
 

--- a/docs/tickets/FOLLOWUP-M4-DUNNING-UX-GRUNDEINSTELLUNGEN-TAB.md
+++ b/docs/tickets/FOLLOWUP-M4-DUNNING-UX-GRUNDEINSTELLUNGEN-TAB.md
@@ -1,8 +1,8 @@
 # FOLLOWUP — M4 Mahn-UX: Tab „Grundeinstellungen“ / Routing
 
-**Status:** Backlog (kein Wave-3-Pflichtscope). **Teil erledigt (Code):** Deep-Link `#/finanz-grundeinstellungen` und Tab-Auflösung in [`apps/web/src/lib/hash-route.ts`](../../apps/web/src/lib/hash-route.ts); Schnellzugriff-Kachel „Mahn-Grundeinstellungen“ für ausgewählte Rollen in `apps/web/src/lib/role-quick-actions.ts` + `App.tsx`.  
-**Stand 2026-04-27 (Acht-Schritte-Plan / Wave3-12):** weiteres UX (z. B. vollständiger dedizierter Tab-Ort ohne Duplikat-Logik laut **Zielbild** unten) nur nach **expliziter PL-Priorität** — kein zusätzlicher Implementierungs-PR durch Agenten ohne PL-Freigabe.  
-**Stand 2026-04-27 (Wave3-13 / Agent A — Doku-Spur):** Umsetzungs-Backlog unten mit `main` abgeglichen (alles abgehakt). **Stand Agent-A (Wave3-14):** Backlog-Abschnitt vollständig abgehakt (Hash-Alias, Schnellzugriff-Rollen, Copy/IA); offenes **Zielbild** (dedizierter Tab ohne Duplikat-Logik) unverändert **nur nach PL**.  
+**Status:** Zielbild-Routing **erledigt** (2026-04-28). **Code:** [`hash-route.ts`](../../apps/web/src/lib/hash-route.ts), [`App.tsx`](../../apps/web/src/App.tsx), Schnellzugriff [`role-quick-actions.ts`](../../apps/web/src/lib/role-quick-actions.ts).  
+**Stand 2026-04-28:** Zielbild (ein kanonischer Hash für Grundeinstellungen, kein paralleles `?tab=`) umgesetzt; PL-Sperre für diesen Slice durch Nutzeranweisung „Sperre aufheben und ausführen“ aufgehoben.  
+**Historisch 2026-04-27:** Kein Agent-PR ohne PL-Priorität (Wave3-12/14); Backlog unten vollständig.
 
 **Herkunft:** [`M4-MINI-SLICE-5B-ORCHESTRATION-2026-04-24.md`](./M4-MINI-SLICE-5B-ORCHESTRATION-2026-04-24.md) PL-Tabelle Zeile **10** (UI-Ort: bislang Finanz-Vorbereitung; Umzug Grundeinstellungen = späteres UX-Slice).
 
@@ -21,6 +21,6 @@
 
 ## Umsetzungs-Backlog (Rest — nach PL-Priorität)
 
-- [x] Tab-State und Hash: Kanon **`#/finanz-vorbereitung?tab=grundeinstellungen`**; Alias `#/finanz-grundeinstellungen` wird beim ersten Paint per `replaceState` normalisiert ([`normalizeFinancePrepHashToCanon`](../../apps/web/src/lib/hash-route.ts) + Aufruf in [`App.tsx`](../../apps/web/src/App.tsx)); Tab-Wechsel in der UI weiter über `applyFinancePrepTabToLocationHash`.
+- [x] Tab-State und Hash: Kanon **`#/finanz-grundeinstellungen`** für Tab Grundeinstellungen; `#/finanz-vorbereitung?tab=grundeinstellungen` wird beim ersten Paint per `replaceState` vereinheitlicht ([`financePrepHashWithTab`](../../apps/web/src/lib/hash-route.ts), [`normalizeFinancePrepHashToCanon`](../../apps/web/src/lib/hash-route.ts) + Aufruf in [`App.tsx`](../../apps/web/src/App.tsx)); Tab-Wechsel über `applyFinancePrepTabToLocationHash`.
 - [x] Schnellzugriff: Kachel **Mahn-Grundeinstellungen** auch für **VERTRIEB_BAULEITUNG** und **VIEWER** ([`role-quick-actions.ts`](../../apps/web/src/lib/role-quick-actions.ts)); PL kann das Navigationsmodell bei Bedarf schriftlich schärfen oder zurücknehmen.
-- [x] Copy/IA: Seitentitel (`h2`) bei Tab **Grundeinstellungen** / Alias `#/finanz-grundeinstellungen`: „Finanz (Vorbereitung) — Mahn-Grundeinstellungen“ in [`FinancePreparation.tsx`](../../apps/web/src/components/FinancePreparation.tsx).
+- [x] Copy/IA: Seitentitel (`h2`) bei Tab **Grundeinstellungen** / Deep-Link `#/finanz-grundeinstellungen`: „Finanz (Vorbereitung) — Mahn-Grundeinstellungen“ in [`FinancePreparation.tsx`](../../apps/web/src/components/FinancePreparation.tsx).


### PR DESCRIPTION
## Änderung

- Tab **Grundeinstellungen**: `applyFinancePrepTabToLocationHash` setzt `#/finanz-grundeinstellungen` (statt `?tab=grundeinstellungen`).
- `normalizeFinancePrepHashToCanon`: Lesezeichen `#/finanz-vorbereitung?tab=grundeinstellungen` → `#/finanz-grundeinstellungen`.
- Tests, Schnellzugriff-Text, Codemap, FOLLOWUP-Ticket, FinanceFeatureMatrix.

## Nicht-Ziel

Kein OpenAPI-/Backend-/B5-/Audit-Änderung.

## Lokale Vorprüfung

- `npm run verify:ci` grün
- `npx playwright test e2e/login-finance-smoke.spec.ts` grün

## §5a

Nach grünem `backend` + `e2e-smoke` zum PR-Head: §5a-pre Kommentar mit Run-URL.

Made with [Cursor](https://cursor.com)