### PR TITLE
feat(lv): GET single structure node (§9 read path)

### DIFF
--- a/docs/adr/0013-lv-section9-hierarchy-and-text-separation.md
+++ b/docs/adr/0013-lv-section9-hierarchy-and-text-separation.md
@@ -1,4 +1,4 @@
-# ADR-0013 — LV §9 Hierarchie-Lesepfade (`/structure`, `/positions/{id}`)
+# ADR-0013 — LV §9 Hierarchie-Lesepfade (`/structure`, `/nodes/{id}`, `/positions/{id}`)
 
 **Status:** ACCEPTED (2026-05-04)
 
@@ -8,11 +8,12 @@ LV §9 (Hierarchie, Texttrennung Systemtext vs. Bearbeitungstext, SoT `LV_VERSIO
 
 ## Entscheidung
 
-### D1 — Zwei zusätzliche **read-only** GET-Endpunkte (Projektion)
+### D1 — Zusätzliche **read-only** GET-Endpunkte (Projektion)
 
 | Pfad | Antwort |
 |------|---------|
 | `GET /lv/versions/{lvVersionId}/structure` | `LvHierarchySnapshot`: `lvVersionId`, `structureNodes[]`, `positions[]` — dieselben Knoten/Positionen wie im Snapshot, **ohne** `catalog` und **ohne** `version`-Kopf. JSON-Felder wie bestehende Ressourcen (`editingText` auf Knoten/Positionen). |
+| `GET /lv/versions/{lvVersionId}/nodes/{nodeId}` | Ein `LvStructureNode` wie im Snapshot (Schema-Alias OpenAPI: `LvStructureNode` = `LvStructureNodeResource`). 404 wenn Knoten fehlt oder nicht zu dieser Version gehört. |
 | `GET /lv/versions/{lvVersionId}/positions/{positionId}` | Eine `LvPosition` wie im Snapshot (Schema-Alias OpenAPI: `LvPositionV2` = `LvPositionResource`). 404 wenn Position fehlt oder nicht zu dieser Version gehört. |
 
 ### D2 — OpenAPI-Aliase

--- a/docs/api-contract.yaml
+++ b/docs/api-contract.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: ERP Backend API (Phase 1 + Phase 2 Inc1 + Inc2 LV §9 + FIN-1/2/3/4 Finance)
-  version: 1.28.1-phase2-lv-section9-hierarchy
+  version: 1.28.2-phase2-lv-section9-single-node
   description: |
     **PWA / Browser-Anbindung**
     - **CORS**: Umgebungsvariable `CORS_ORIGINS` — kommagetrennte, exakte Origins (z. B. `https://app.example.com,http://localhost:5173`). Leer oder unset: keine `Access-Control-*`-Header (gleiche Origin oder Server-zu-Server).
@@ -2139,6 +2139,40 @@ paths:
                 $ref: '#/components/schemas/LvPositionV2'
         '404':
           description: LV_VERSION_NOT_FOUND | LV_POSITION_NOT_FOUND
+        '403':
+          description: AUTH_ROLE_FORBIDDEN | TENANT_SCOPE_VIOLATION
+        '401':
+          description: Authentifizierung fehlgeschlagen
+  /lv/versions/{lvVersionId}/nodes/{nodeId}:
+    get:
+      description: |
+        Liest einen Strukturknoten der angegebenen LV-Version §9 (mandantenisoliert). 404 wenn der Knoten nicht zu dieser Version gehört.
+        Schema wie Snapshot/`GET …/structure` — siehe ADR-0013.
+      security:
+        - bearerToken: []
+      parameters:
+        - $ref: '#/components/parameters/TenantScopeHeader'
+        - in: path
+          name: lvVersionId
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - in: path
+          name: nodeId
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: LV-Strukturknoten
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LvStructureNode'
+        '404':
+          description: LV_VERSION_NOT_FOUND | LV_NODE_NOT_FOUND
         '403':
           description: AUTH_ROLE_FORBIDDEN | TENANT_SCOPE_VIOLATION
         '401':

--- a/docs/contracts/FIN4-external-client-integration.md
+++ b/docs/contracts/FIN4-external-client-integration.md
@@ -40,6 +40,10 @@ Server-zu-Server: Header direkt lesen. **Browser + CORS:** nur sichtbar, wenn di
 
 Vollständige Schemas: `docs/api-contract.yaml`. Mapping: `docs/contracts/finance-fin0-openapi-mapping.md`.
 
+## Neu ab `1.28.2` (Phase 2 — LV §9 Einzelknoten-Lesepfad)
+
+- **`GET /lv/versions/{lvVersionId}/nodes/{nodeId}`:** ein Strukturknoten wie in `structureNodes[]` / Snapshot; **404** `LV_NODE_NOT_FOUND`, wenn die ID keine Knoten-ID dieser Version ist (z. B. Positions-ID übergeben).
+
 ## Neu ab `1.28.1` (Phase 2 — LV §9 Hierarchie-Lesepfad, Contract-Klarstellung)
 
 - **`GET /lv/versions/{lvVersionId}/structure`**, **`GET /lv/versions/{lvVersionId}/positions/{positionId}`:** Projektion wie Snapshot-Knoten/-Positionen (`editingText`); OpenAPI-Schemata **`LvStructureNode`** / **`LvPositionV2`** sind Aliase zu **`LvStructureNodeResource`** / **`LvPositionResource`**. **`LvHierarchySnapshot`** ohne eingebettete `allowedActions` — SoT weiterhin über **`GET /documents/{id}/allowed-actions`**.

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -414,6 +414,20 @@ export async function buildApp(options?: BuildAppOptions): Promise<FastifyInstan
     }
   });
 
+  app.get("/lv/versions/:lvVersionId/nodes/:nodeId", async (request, reply) => {
+    try {
+      const params = request.params as { lvVersionId: string; nodeId: string };
+      const result = lvHierarchyService.getStructureNodeForHttpHeaders(
+        request.headers,
+        params.lvVersionId,
+        params.nodeId,
+      );
+      return reply.status(200).send(result);
+    } catch (error) {
+      return handleHttpError(error, request, reply);
+    }
+  });
+
   app.post("/lv/versions/:lvVersionId/status", async (request, reply) => {
     try {
       const auth = parseAuthContext(request.headers);

--- a/src/domain/openapi-contract-version.ts
+++ b/src/domain/openapi-contract-version.ts
@@ -2,4 +2,4 @@
  * Single source of truth for public API contract label (must match `docs/api-contract.yaml` `info.version`).
  * CI: `npm run validate:api-contract-yaml` asserts equality.
  */
-export const ERP_OPENAPI_INFO_VERSION = "1.28.1-phase2-lv-section9-hierarchy" as const;
+export const ERP_OPENAPI_INFO_VERSION = "1.28.2-phase2-lv-section9-single-node" as const;

--- a/src/services/lv-hierarchy-service.ts
+++ b/src/services/lv-hierarchy-service.ts
@@ -33,4 +33,17 @@ export class LvHierarchyService {
     }
     return pos;
   }
+
+  public getStructureNodeForHttpHeaders(
+    rawHeaders: unknown,
+    lvVersionId: string,
+    nodeId: string,
+  ): LvStructureNode {
+    const snap = this.lvService.getVersionSnapshotForHttpHeaders(rawHeaders, lvVersionId);
+    const node = snap.structureNodes.find((n) => n.id === nodeId);
+    if (!node) {
+      throw new DomainError("LV_NODE_NOT_FOUND", "Strukturknoten nicht gefunden", 404);
+    }
+    return node;
+  }
 }

--- a/test/lv-hierarchy-read.test.ts
+++ b/test/lv-hierarchy-read.test.ts
@@ -123,4 +123,60 @@ describe("LV §9 Hierarchie-Lesepfade (structure / single position)", () => {
     expect(res.statusCode).toBe(404);
     expect(res.json().code).toBe("LV_VERSION_NOT_FOUND");
   });
+
+  it("GET /lv/versions/:id/nodes/:nid returns single structure node (TITEL)", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/lv/versions/${SEED_IDS.lvVersionId}/nodes/${SEED_IDS.lvTitelId}`,
+      headers: buildHeaders(),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { id: string; kind: string; lvVersionId: string; editingText: string };
+    expect(body.id).toBe(SEED_IDS.lvTitelId);
+    expect(body.kind).toBe("TITEL");
+    expect(body.lvVersionId).toBe(SEED_IDS.lvVersionId);
+    expect(body.editingText).toContain("Titel");
+  });
+
+  it("GET node returns 404 when LV version missing", async () => {
+    const fakeVersion = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaa0999";
+    const res = await app.inject({
+      method: "GET",
+      url: `/lv/versions/${fakeVersion}/nodes/${SEED_IDS.lvBereichId}`,
+      headers: buildHeaders(),
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe("LV_VERSION_NOT_FOUND");
+  });
+
+  it("GET node returns 404 when id is not a node of this version", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/lv/versions/${SEED_IDS.lvVersionId}/nodes/${SEED_IDS.lvPositionSeedA}`,
+      headers: buildHeaders(),
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe("LV_NODE_NOT_FOUND");
+  });
+
+  it("VIEWER may read single node", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/lv/versions/${SEED_IDS.lvVersionId}/nodes/${SEED_IDS.lvBereichId}`,
+      headers: buildHeaders("VIEWER"),
+    });
+    expect(res.statusCode).toBe(200);
+    expect((res.json() as { kind: string }).kind).toBe("BEREICH");
+  });
+
+  it("GET node is tenant-isolated (404)", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/lv/versions/${SEED_IDS.lvVersionId}/nodes/${SEED_IDS.lvTitelId}`,
+      headers: buildHeaders("ADMIN", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe("LV_VERSION_NOT_FOUND");
+  });
+
 });


### PR DESCRIPTION
## Scope
- `GET /lv/versions/{lvVersionId}/nodes/{nodeId}` read-only, tenant-isolated (ADR-0013).
- OpenAPI **1.28.2-phase2-lv-section9-single-node**; FIN4 integrator note for **1.28.2**.

## Verify (local)
- `npm run verify:pre-merge` — green
- `npm run verify:ci:local-db` — green

## Nach diesem Merge
Branch `feat/export-runs-shell-spur-a` auf aktuelles `main` rebasen (`git fetch origin && git rebase origin/main`), damit der Export-PR nur den zweiten Commit zeigt.

Made with [Cursor](https://cursor.com)