### PR TITLE
fix(api): explicit rateLimit on tenant PWA display settings routes

### DIFF
--- a/src/api/tenant-pwa-display-settings-routes.ts
+++ b/src/api/tenant-pwa-display-settings-routes.ts
@@ -4,6 +4,16 @@ import type { AuthorizationService } from "../services/authorization-service.js"
 import type { TenantPwaDisplaySettingsService } from "../services/tenant-pwa-display-settings-service.js";
 import { patchTenantPwaDisplaySettingsSchema } from "../validation/schemas.js";
 
+const tenantPwaDisplaySettingsReadRateLimit = {
+  max: 60,
+  timeWindow: "1 minute" as const,
+};
+
+const tenantPwaDisplaySettingsWriteRateLimit = {
+  max: 20,
+  timeWindow: "1 minute" as const,
+};
+
 export function registerTenantPwaDisplaySettingsRoutes(
   app: FastifyInstance,
   deps: {
@@ -11,31 +21,39 @@ export function registerTenantPwaDisplaySettingsRoutes(
     tenantPwaDisplaySettingsService: TenantPwaDisplaySettingsService;
   },
 ): void {
-  app.get("/tenant/pwa-display-settings", async (request, reply) => {
-    try {
-      const auth = parseAuthContext(request.headers);
-      deps.authorizationService.assertCanReadInvoice(auth.role);
-      const data = await deps.tenantPwaDisplaySettingsService.getReadModel(auth.tenantId);
-      return reply.status(200).send({ data });
-    } catch (error) {
-      return handleHttpError(error, request, reply);
-    }
-  });
+  app.get(
+    "/tenant/pwa-display-settings",
+    { config: { rateLimit: tenantPwaDisplaySettingsReadRateLimit } },
+    async (request, reply) => {
+      try {
+        const auth = parseAuthContext(request.headers);
+        deps.authorizationService.assertCanReadInvoice(auth.role);
+        const data = await deps.tenantPwaDisplaySettingsService.getReadModel(auth.tenantId);
+        return reply.status(200).send({ data });
+      } catch (error) {
+        return handleHttpError(error, request, reply);
+      }
+    },
+  );
 
-  app.patch("/tenant/pwa-display-settings", async (request, reply) => {
-    try {
-      const auth = parseAuthContext(request.headers);
-      deps.authorizationService.assertCanManageInvoiceTaxSettings(auth.role);
-      const body = patchTenantPwaDisplaySettingsSchema.parse(request.body);
-      const data = await deps.tenantPwaDisplaySettingsService.patchExpertMode({
-        tenantId: auth.tenantId,
-        actorUserId: auth.userId,
-        reason: body.reason,
-        pwaExpertModeEnabled: body.pwaExpertModeEnabled,
-      });
-      return reply.status(200).send({ data });
-    } catch (error) {
-      return handleHttpError(error, request, reply);
-    }
-  });
+  app.patch(
+    "/tenant/pwa-display-settings",
+    { config: { rateLimit: tenantPwaDisplaySettingsWriteRateLimit } },
+    async (request, reply) => {
+      try {
+        const auth = parseAuthContext(request.headers);
+        deps.authorizationService.assertCanManageInvoiceTaxSettings(auth.role);
+        const body = patchTenantPwaDisplaySettingsSchema.parse(request.body);
+        const data = await deps.tenantPwaDisplaySettingsService.patchExpertMode({
+          tenantId: auth.tenantId,
+          actorUserId: auth.userId,
+          reason: body.reason,
+          pwaExpertModeEnabled: body.pwaExpertModeEnabled,
+        });
+        return reply.status(200).send({ data });
+      } catch (error) {
+        return handleHttpError(error, request, reply);
+      }
+    },
+  );
 }


### PR DESCRIPTION
## Why
Post-merge follow-up to [#98](https://github.com/rhermann90/ERP/pull/98): GHAS **CodeQL** reported new **high** `js/missing-rate-limiting` findings on `GET|PATCH /tenant/pwa-display-settings` because handlers use `parseAuthContext` without an explicit per-route `config.rateLimit` (global `@fastify/rate-limit` is not modeled).

## Change
Same pattern as [`finance-invoice-tax-routes.ts`](src/api/finance-invoice-tax-routes.ts): read **60/min**, write **20/min** per IP.

## Verification
- `npm run typecheck`

Made with [Cursor](https://cursor.com)