### PR TITLE
chore(deps): React 19.2.6 + react-dom 19.2.6 (PR #115/#116)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "react": "^19.0.0",
+    "react": "^19.2.6",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "^19.2.6",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.2.6"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "version": "0.1.0",
       "dependencies": {
         "react": "^19.2.6",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.2.6"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",
@@ -7915,13 +7915,17 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {
@@ -8329,7 +8333,9 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "license": "MIT"
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
     "apps/web": {
       "version": "0.1.0",
       "dependencies": {
-        "react": "^19.0.0",
+        "react": "^19.2.6",
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
@@ -7870,7 +7870,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     },
     "@hono/node-server": "1.19.13",
     "fast-uri": "3.1.2",
-    "hono": "4.12.18"
+    "hono": "4.12.18",
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- Merges the dependency intent of **#116** (react 19.2.6) and **#115** (react-dom 19.2.6) in one branch off `main`.
- Resolves the **package.json / package-lock.json** merge conflict that blocked #115 after #116’s changes.
- Adds root **npm overrides** for `react` and `react-dom` at **19.2.6** so nested `@testing-library/react` no longer pulls `react-dom@19.2.5` while `react` is 19.2.6 (Vitest fails with React’s version-mismatch guard).

## Verification
- `npm run test -w apps/web` (Vitest) — green locally.

Closes #115
Closes #116

Made with [Cursor](https://cursor.com)